### PR TITLE
add compiler flags flag to run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>>
                         .required(false)
                         .action(clap::ArgAction::SetTrue)
                         .help("Run the day with the \"test\" file"),
+                    Arg::new("compiler-flags")
+                        .short('C')
+                        .long("compiler-flags")
+                        .required(false)
+                        .default_value(std::env::var("RUSTFLAGS").unwrap_or(String::new()))
+                        .allow_hyphen_values(true)
+                        .help("Flags to send to rustc"),
                 ])
                 .about("Runs the given day"),
         )

--- a/src/run.rs
+++ b/src/run.rs
@@ -60,9 +60,11 @@ pub async fn run(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
     }
 
     let input = get_input_file(matches).await?;
+    let flags = matches.get_one::<String>("compiler-flags").unwrap();
 
     let res = tokio::process::Command::new("cargo")
         .args(["run", "--color", "always", "--bin", format!("day_{:02}", day).as_str(), &input])
+        .env("RUSTFLAGS", flags)
         .current_dir(dir)
         .output()
         .await?;


### PR DESCRIPTION
Sometimes I need/want to pass flags directly to rustc.
For instance, if the day require number crunching,  passing "-O3" is nice:
```
rustc -C opt-level=3 main.rs
```
Passing flags directly to rustc can be done with a RUSTFLAGS env variable
Although the case for -O3 can seem a bit weird?
```
cargo aoc run -C "-C opt-level=3"
```
This is just because the flag itself is weird.

Something like
```
cargo aoc run -C "--edition 2021"
```
Looks better


Note that RUSTFLAGS="" does nothing, in the case we dont pass any flags

fixes #8 