### PR TITLE
refactor code and get rid of all unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ clap = { version = "4.0.27", features = ["derive", "cargo", "string"] }
 dotenv = "0.15.0"
 reqwest = "0.11.13"
 sanitize_html = "0.7.0"
+serde = "1.0.148"
 strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.22.0", features = ["full"] }

--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -1,11 +1,8 @@
 use clap::ArgMatches;
 
-pub fn get_day(matches: &ArgMatches) -> Result<u32, std::num::ParseIntError>
-{
-    matches.get_one::<String>("day").unwrap().parse()
-}
+use crate::{error::AocError, run::get_day};
 
-pub async fn clippy(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
+pub async fn clippy(matches: &ArgMatches) -> Result<(), AocError>
 {
     let day = get_day(matches)?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,61 @@
+pub enum AocError
+{
+    TokenError,
+    ReqwestError(reqwest::Error),
+    DownloadError(String),
+    SanitizeHtml,
+    ParseStdout,
+    InvalidRunDay,
+    InvalidSubmitDay,
+    InvalidYear,
+    ParseIntError,
+    ArgMatches,
+    Utf8Error,
+    StdIoErr(std::io::Error),
+}
+
+macro_rules! impl_from_helper {
+    ($from:ty, $to: expr) => {
+        impl From<$from> for AocError
+        {
+            fn from(e: $from) -> Self
+            {
+                $to(e)
+            }
+        }
+    };
+}
+
+macro_rules! impl_print {
+    ($($from: ty),*) => {$(
+        impl $from for AocError
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+            {
+                match self
+                {
+                    AocError::TokenError => write!(f, "Could not find AOC_TOKEN to download input or submit"),
+                    AocError::ReqwestError(e) => write!(f, "reqwest error: {}", e),
+                    AocError::SanitizeHtml => write!(f, "Error on sanitizing answer"),
+                    AocError::ParseStdout => write!(f, "Error on getting answer from task"),
+                    AocError::InvalidRunDay => write!(f, "Day must be between 1 and 25"),
+                    AocError::InvalidSubmitDay => write!(f, "Can only submit 1 or 2"),
+                    AocError::InvalidYear => write!(f, "Year must be between 2015 ..= current year"),
+                    AocError::ParseIntError => write!(f, "Error parsing to number"),
+                    AocError::ArgMatches => write!(f, "Error on getting argument"),
+                    AocError::StdIoErr(e) => write!(f, "{}", e),
+                    AocError::DownloadError(e) => write!(f, "{}", e),
+                    AocError::Utf8Error => write!(f, "Error on parsing to utf-8"),
+                }
+            }
+        }
+    )*}
+}
+
+impl_from_helper!(dotenv::Error, |_| AocError::TokenError);
+impl_from_helper!(std::num::ParseIntError, |_| AocError::ParseIntError);
+impl_from_helper!(std::str::Utf8Error, |_| AocError::Utf8Error);
+impl_from_helper!(std::io::Error, |e| Self::StdIoErr(e));
+impl_from_helper!(reqwest::Error, |e| Self::ReqwestError(e));
+
+impl_print!(std::fmt::Display, std::fmt::Debug);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
 use chrono::Datelike;
 use clap::{builder::OsStr, Arg, Command};
+use error::AocError;
 mod clippy;
+mod error;
 mod run;
 mod setup;
 mod token;
 mod util;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>>
+async fn main() -> Result<(), AocError>
 {
     dotenv::dotenv().ok();
     let mut cmd = Command::new("cargo-aoc")
@@ -68,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>>
                         .short('C')
                         .long("compiler-flags")
                         .required(false)
-                        .default_value(std::env::var("RUSTFLAGS").unwrap_or(String::new()))
+                        .default_value(std::env::var("RUSTFLAGS").unwrap_or_default())
                         .allow_hyphen_values(true)
                         .help("Flags to send to rustc"),
                     Arg::new("submit")
@@ -108,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>>
             setup::setup(matches).await.expect("Couldn't setup project properly")
         },
         Some(("run", matches)) => run::run(matches).await?,
-        Some(("token", matches)) => token::token(matches).await,
+        Some(("token", matches)) => token::token(matches).await?,
         Some(("clippy", matches)) => clippy::clippy(matches).await?,
         _ =>
         {

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,40 +1,44 @@
 use chrono::prelude::*;
 use clap::ArgMatches;
 
-use crate::util::{
-    file::{cargo_path, day_path, download_input_file},
-    get_year,
-    submit::{self, get_submit_day},
+use crate::{
+    error::AocError,
+    util::{
+        file::{cargo_path, day_path, download_input_file},
+        get_year,
+        submit::{self, get_submit_day},
+    },
 };
 
-pub fn get_day(matches: &ArgMatches) -> Result<u32, std::num::ParseIntError>
+pub fn get_day(matches: &ArgMatches) -> Result<u32, AocError>
 {
-    matches.get_one::<String>("day").unwrap().parse()
-}
-
-async fn get_input_file(matches: &ArgMatches) -> Result<String, Box<dyn std::error::Error>>
-{
-    if matches.get_flag("test")
+    let day = matches.get_one::<String>("day").ok_or(AocError::ArgMatches)?.parse::<u32>()?;
+    if !(1..=25).contains(&day)
     {
-        Ok("test".to_owned())
+        Err(AocError::InvalidRunDay)
     }
     else
     {
-        Ok("input".to_owned())
+        Ok(day)
     }
 }
 
-pub async fn run(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
+fn get_input_file(matches: &ArgMatches) -> &str
+{
+    if matches.get_flag("test")
+    {
+        "test"
+    }
+    else
+    {
+        "input"
+    }
+}
+
+pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
 {
     let day = get_day(matches)?;
-
-    if !(1..=25).contains(&day)
-    {
-        return Err(Box::<_>::from("Day must be between 1 and 25"));
-    }
-
-    let cwd = std::env::current_dir()?;
-    let path = cargo_path(&cwd).await.unwrap_or(cwd);
+    let path = cargo_path().await.unwrap_or(std::env::current_dir()?);
     let dir = day_path(path, day).await?;
 
     if !dir.join("input").exists()
@@ -44,16 +48,16 @@ pub async fn run(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
         let current_month = Utc::now().month();
         if year < 2015 || year > current_year || (year == current_year && current_month < 12)
         {
-            return Err(Box::<_>::from(format!("No advent of code for {}", year)));
+            return Err(AocError::InvalidYear);
         }
         download_input_file(day, year, &dir).await?;
     }
 
-    let input = get_input_file(matches).await?;
-    let flags = matches.get_one::<String>("compiler-flags").unwrap();
+    let input = get_input_file(matches);
+    let flags = matches.get_one::<String>("compiler-flags").ok_or(AocError::ArgMatches)?;
 
     let res = tokio::process::Command::new("cargo")
-        .args(["run", "--color", "always", "--bin", format!("day_{:02}", day).as_str(), &input])
+        .args(["run", "--color", "always", "--bin", format!("day_{:02}", day).as_str(), input])
         .env("RUSTFLAGS", flags)
         .current_dir(dir)
         .output()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,8 +1,8 @@
 use clap::ArgMatches;
 
-use crate::util::get_year;
+use crate::{error::AocError, util::get_year};
 
-async fn setup_template_project(year: i32) -> Result<(), Box<dyn std::error::Error>>
+async fn setup_template_project(year: i32) -> Result<(), AocError>
 {
     tokio::process::Command::new("cargo")
         .args(["new", &format!("year_{}", year)])
@@ -20,7 +20,7 @@ async fn setup_template_project(year: i32) -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
-async fn get_session_token() -> Result<(), Box<dyn std::error::Error>>
+async fn get_session_token() -> Result<(), AocError>
 {
     if dotenv::var("AOC_TOKEN").is_err()
     {
@@ -40,7 +40,7 @@ async fn get_session_token() -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-pub async fn setup(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
+pub async fn setup(args: &ArgMatches) -> Result<(), AocError>
 {
     let year = get_year(args)?;
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,12 +1,12 @@
 use clap::ArgMatches;
 
-use crate::util::file::*;
+use crate::{error::AocError, util::file::*};
 
-pub async fn token(matches: &ArgMatches)
+pub async fn token(matches: &ArgMatches) -> Result<(), AocError>
 {
     if let Some(token) = matches.get_one::<String>("set")
     {
-        let mut path = cargo_path(std::env::current_dir().unwrap()).await.unwrap();
+        let mut path = cargo_path().await?;
         path.push(".env");
 
         tokio::fs::write(path, format!("AOC_TOKEN={token}"))
@@ -20,4 +20,5 @@ pub async fn token(matches: &ArgMatches)
             dotenv::var("AOC_TOKEN").unwrap_or_else(|_| "Could not find token".to_string())
         );
     }
+    Ok(())
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,41 +1,20 @@
-use std::fmt::Display;
-
 use clap::ArgMatches;
 
+use crate::error::AocError;
+
 pub mod file;
+pub mod request;
 pub mod submit;
 
-#[derive(Debug)]
-pub enum ParseArgError
+pub fn get_year(matches: &ArgMatches) -> Result<i32, AocError>
 {
-    ParseError,
-    Invalid(String),
-}
-
-impl Display for ParseArgError
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
-    {
-        match self
-        {
-            ParseArgError::ParseError =>
-            {
-                write!(f, "Couldn't parse input. Check that you are using the correct type")
-            },
-            ParseArgError::Invalid(s) => write!(f, "{}", s),
-        }
-    }
-}
-
-pub fn get_year(matches: &ArgMatches) -> Result<i32, std::num::ParseIntError>
-{
-    let year = matches.get_one::<String>("year").unwrap();
+    let year = matches.get_one::<String>("year").ok_or(AocError::ArgMatches)?;
     if year.chars().count() == 2
     {
-        format!("20{}", year).parse()
+        Ok(format!("20{}", year).parse()?)
     }
     else
     {
-        year.parse()
+        Ok(year.parse()?)
     }
 }

--- a/src/util/request.rs
+++ b/src/util/request.rs
@@ -1,0 +1,53 @@
+use reqwest::{
+    header::{COOKIE, USER_AGENT},
+    IntoUrl, Response,
+};
+use serde::Serialize;
+
+use crate::error::AocError;
+
+pub struct AocRequest
+{
+    client: reqwest::Client,
+}
+
+impl AocRequest
+{
+    const AOC_USER_AGENT: &str = "github.com/seblj/cargo-aoc by seblyng98@gmail.com";
+
+    pub fn new() -> AocRequest
+    {
+        AocRequest {
+            client: reqwest::Client::new()
+        }
+    }
+
+    fn get_token(&self) -> Result<String, dotenv::Error>
+    {
+        dotenv::var("AOC_TOKEN")
+    }
+
+    async fn request(self, req: reqwest::RequestBuilder) -> Result<Response, AocError>
+    {
+        Ok(req
+            .header(COOKIE, format!("session={}", self.get_token()?))
+            .header(USER_AGENT, AocRequest::AOC_USER_AGENT)
+            .send()
+            .await?)
+    }
+
+    pub async fn get<U: IntoUrl>(self, url: U) -> Result<Response, AocError>
+    {
+        let req = self.client.get(url);
+        self.request(req).await
+    }
+
+    pub async fn post<T, U>(self, url: U, form: &T) -> Result<Response, AocError>
+    where
+        U: IntoUrl,
+        T: Serialize + ?Sized,
+    {
+        let req = self.client.post(url).form(form);
+        self.request(req).await
+    }
+}

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -1,40 +1,23 @@
 use std::collections::HashMap;
 
 use clap::ArgMatches;
-use reqwest::header::{COOKIE, USER_AGENT};
 use sanitize_html::rules::predefined::DEFAULT;
 
-use super::ParseArgError;
+use super::request::AocRequest;
+use crate::error::AocError;
 
-pub fn get_submit_day(matches: &ArgMatches) -> Option<Result<Task, ParseArgError>>
+pub fn get_submit_day(matches: &ArgMatches) -> Option<Result<Task, AocError>>
 {
     let day = matches.get_one::<String>("submit")?;
     let Ok(day) = day.parse::<u8>() else {
-        return Some(Err(ParseArgError::ParseError));
+        return Some(Err(AocError::ParseIntError));
     };
 
     match day
     {
         1 => Some(Ok(Task::One)),
         2 => Some(Ok(Task::Two)),
-        _ => Some(Err(ParseArgError::Invalid(
-            "Only allowed to pass in 1 or 2 for submit".to_string(),
-        ))),
-    }
-}
-
-impl std::fmt::Display for SubmitError
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
-    {
-        match self
-        {
-            SubmitError::TokenError => write!(f, "Could not find AOC_TOKEN"),
-            SubmitError::HttpRequestError => write!(f, "Error on submitting answer"),
-            SubmitError::SanitizeHtmlError => write!(f, "Error on sanitizing answer"),
-            SubmitError::ParseStdoutError => write!(f, "Error on getting answer from task"),
-            SubmitError::HttpTextError => write!(f, "Error on getting response text"),
-        }
+        _ => Some(Err(AocError::InvalidSubmitDay)),
     }
 }
 
@@ -59,7 +42,7 @@ impl std::fmt::Display for Task
 
 fn get_answer(out: &str, task: &Task) -> Option<String>
 {
-    let start = out.split(&format!("Task {}: ", task.to_string())).nth(1)?;
+    let start = out.split(&format!("Task {}: ", task)).nth(1)?;
     let encoded_answer = start.split_once('\n').unwrap_or((start, "")).0;
     let answer = strip_ansi_escapes::strip(encoded_answer).ok()?;
     String::from_utf8(answer).ok()
@@ -70,39 +53,21 @@ fn parse_and_sanitize_output(output: &str) -> Option<String>
     let start = output.find("<article><p>")?;
     let end = output.find("</p></article>")?;
     let body = &output[start..end];
-    sanitize_html::sanitize_str(&DEFAULT, &body).ok()
+    sanitize_html::sanitize_str(&DEFAULT, body).ok()
 }
 
-pub enum SubmitError
+pub async fn submit(output: &str, task: &Task, day: u32, year: i32) -> Result<String, AocError>
 {
-    TokenError,
-    HttpRequestError,
-    SanitizeHtmlError,
-    ParseStdoutError,
-    HttpTextError,
-}
-
-pub async fn submit(output: &str, task: &Task, day: u32, year: i32) -> Result<String, SubmitError>
-{
-    let answer = get_answer(output, &task).ok_or_else(|| SubmitError::ParseStdoutError)?;
-    let token = dotenv::var("AOC_TOKEN").map_err(|_| SubmitError::TokenError)?;
-    let client = reqwest::Client::new();
+    let answer = get_answer(output, task).ok_or(AocError::ParseStdout)?;
     let url = format!("https://adventofcode.com/{}/day/{}/answer", year, day);
 
-    let mut params = HashMap::new();
-    params.insert("level", if task == &Task::One { 1 } else { 2 }.to_string());
-    params.insert("answer", answer);
-    let res = client
-        .post(&url)
-        .form(&params)
-        .header(COOKIE, format!("session={}", token))
-        .header(USER_AGENT, "https://github.com/seblj/cargo-aoc by seblyng98@gmail.com")
-        .send()
-        .await
-        .map_err(|_| SubmitError::HttpRequestError)?;
-    let text = &res.text().await.map_err(|_| SubmitError::HttpTextError)?.to_string();
-    let parsed_output =
-        parse_and_sanitize_output(text).ok_or_else(|| SubmitError::SanitizeHtmlError)?;
+    let mut form = HashMap::new();
+    form.insert("level", if task == &Task::One { 1 } else { 2 }.to_string());
+    form.insert("answer", answer);
+    let res = AocRequest::new().post(&url, &form).await?;
+
+    let text = &res.text().await?;
+    let parsed_output = parse_and_sanitize_output(text).ok_or(AocError::SanitizeHtml)?;
 
     Ok(parsed_output)
 }


### PR DESCRIPTION
Larger refactor of code
- Get rid of all unwrap
- Fix clippy warnings
- Introduce `AocError` and try to use it to avoid a few allocaations with `Box<dyn std::error::Error>`

Probably more can be done to avoid even more allocations, but I think it is okay for now maybe.

Suggestions for improvements are welcome! 🚀 