### PR TITLE
Feature/criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ sanitize_html = "0.7.0"
 serde = "1.0.148"
 strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.22.0", features = ["full"] }
+
+criterion = { version = "0.3", optional = true }
+
+
+[features]
+default = ["bench"]
+bench = ["criterion"]

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,109 @@
+use std::path::{Path, PathBuf};
+
+use clap::ArgMatches;
+use tokio::fs;
+
+use crate::{
+    error::AocError,
+    util::{file::*, get_day},
+};
+
+async fn create_file(path: &Path) -> Result<(), AocError>
+{
+    let folder = path.join(".bench");
+
+    let file = fs::read_to_string(path.join("main.rs")).await?;
+    let file = file.replace("fn main()", "fn not_main()");
+
+    let tests = r#"
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+fn from_elem(c: &mut Criterion)
+{
+    let input = read_input("XXX");
+
+    c.bench_function("task_one", |b| b.iter(|| task_one(black_box(&input))));
+    c.bench_function("task_two", |b| b.iter(|| task_two(black_box(&input))));
+}
+
+criterion_group!(benches, from_elem);
+criterion_main!(benches);
+"#;
+
+    let remove_errors = "#![allow(dead_code)]";
+
+    let input = path.join("input");
+    let tests = tests.replace("XXX", &input.display().to_string());
+
+    let file = format!("{}\n{}\n{}", remove_errors, file, tests);
+
+    fs::write(folder.join("benches").join("my_benchmark.rs"), file).await?;
+
+    Ok(())
+}
+
+async fn create_bench_foler(path: &Path) -> Result<(), AocError>
+{
+    let folder = path.join(".bench");
+    fs::create_dir(&folder).await?;
+
+    let template = format!("{}/template/Cargo.toml.benchmark", env!("CARGO_MANIFEST_DIR"));
+
+    fs::copy(template, folder.join("Cargo.toml")).await?;
+    fs::create_dir(folder.join("benches")).await?;
+
+    Ok(())
+}
+
+// Wanted to use tokio here, but got some issues related to recursive async
+// function. https://rust-lang.github.io/async-book/07_workarounds/04_recursion.html
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), AocError>
+{
+    use std::fs;
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)?
+    {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir()
+        {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+        else
+        {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn bench(matches: &ArgMatches) -> Result<(), AocError>
+{
+    let day = get_day(matches)?;
+    let cargo_folder = cargo_path().await?;
+    let day_path = day_path(cargo_folder, day).await?;
+
+    if !day_path.join(".bench").exists()
+    {
+        create_bench_foler(&day_path).await?;
+    }
+    create_file(&day_path).await?;
+
+    tokio::process::Command::new("cargo")
+        .arg("bench")
+        .current_dir(day_path.join(".bench"))
+        .spawn()?
+        .wait()
+        .await?;
+
+    if let Some(output) = matches.get_one::<String>("output").map(PathBuf::from)
+    {
+        if !output.is_dir()
+        {
+            return Err(AocError::ArgError("Path must be a folder".into()));
+        }
+        println!("Copying into {}", output.display());
+        copy_dir_all(day_path.join(".bench/target/criterion"), output)?;
+    }
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum AocError
     ArgMatches,
     Utf8Error,
     StdIoErr(std::io::Error),
+    ArgError(String),
 }
 
 macro_rules! impl_from_helper {
@@ -46,6 +47,7 @@ macro_rules! impl_print {
                     AocError::StdIoErr(e) => write!(f, "{}", e),
                     AocError::DownloadError(e) => write!(f, "{}", e),
                     AocError::Utf8Error => write!(f, "Error on parsing to utf-8"),
+                    AocError::ArgError(e) => write!(f, "{}", e),
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chrono::Datelike;
 use clap::{builder::OsStr, Arg, Command};
 use error::AocError;
+#[cfg(feature = "bench")] mod bench;
 mod clippy;
 mod error;
 mod run;
@@ -101,6 +102,24 @@ async fn main() -> Result<(), AocError>
                 ]),
         );
 
+
+    #[cfg(feature = "bench")]
+    {
+        cmd = cmd.subcommand(
+            Command::new("bench").about("Run benchmarks for the specified day").args([
+                Arg::new("day")
+                    .help("The day to benchmark")
+                    .short('d')
+                    .default_value(chrono::Utc::now().day().to_string()),
+                Arg::new("output")
+                    .help("Output location")
+                    .short('o')
+                    .long("output")
+                    .required(false),
+            ]),
+        );
+    }
+
     let help = cmd.render_help();
     let matches = cmd.get_matches();
     match matches.subcommand()
@@ -112,6 +131,9 @@ async fn main() -> Result<(), AocError>
         Some(("run", matches)) => run::run(matches).await?,
         Some(("token", matches)) => token::token(matches).await?,
         Some(("clippy", matches)) => clippy::clippy(matches).await?,
+
+        #[cfg(feature = "bench")]
+        Some(("bench", matches)) => bench::bench(matches).await?,
         _ =>
         {
             println!("{}", help);

--- a/template/Cargo.toml.benchmark
+++ b/template/Cargo.toml.benchmark
@@ -1,0 +1,11 @@
+[package]
+name = "bench"
+version = "0.0.1"
+edition = "2021"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "my_benchmark"
+harness = false


### PR DESCRIPTION
Adds the `bench` subcommand

It works by, in the {day_XX} folder:
1. creates a `.bench` folder with a rust project within
2. create a basic benchmark suite by copying `day_XX/main.rs` file (renaming main to not_main to please the compiler :wink:) into a premade benchmark file that tests `task_one` and `task_two`
3. runs cargo bench within the `.bench` path

fixes #18 
