### PR TITLE
Feature/progress bar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.22.0", features = ["full"] }
 
 criterion = { version = "0.3", optional = true }
+rayon = "1.6.1"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.22.0", features = ["full"] }
 
 criterion = { version = "0.3", optional = true }
-indicatif = "0.17.2"
+indicatif = { version = "0.17.2", optional = true }
 
 
 [features]
 default = ["bench", "tally"]
 bench = ["criterion"]
-tally = []
+tally = ["indicatif"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.22.0", features = ["full"] }
 
 criterion = { version = "0.3", optional = true }
+indicatif = "0.17.2"
 rayon = "1.6.1"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ tokio = { version = "1.22.0", features = ["full"] }
 
 criterion = { version = "0.3", optional = true }
 indicatif = "0.17.2"
-rayon = "1.6.1"
 
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<(), AocError>
                     "Tallies the  performance of each day and displays information about the \
                      performance",
                 )
-                .arg(Arg::new("runs").long("num-runs").help("Number of runs").default_value("1")),
+                .arg(Arg::new("runs").long("num-runs").help("Number of runs").default_value("10")),
         );
     }
 

--- a/src/tally.rs
+++ b/src/tally.rs
@@ -174,6 +174,10 @@ async fn run_days(
     .unwrap()
     .progress_chars("##-");
 
+    // Sort it to get the progress bars in increasing order
+    let mut days = days;
+    days.sort_unstable_by_key(|k| k.1);
+
     let v = std::thread::scope(|s| {
         let mut handles = Vec::with_capacity(days.len());
         for day in days


### PR DESCRIPTION
# Changes: 🌟 

This feature (unfortunately) does a couple of things 😅:

1. Refactor how days are being built and executed
2. Add progress bar

## Refactor build and execution steps
The reason I removed futures in favour of threads is that running and executing each day is CPU bound.
I also slowed down on the parallelism. Now at most 25 threads will be opening files.
Doing some quick and dirty benchmarks I found that the old implementation took 10 seconds for `--num-runs 500` while the improved takes 4 seconds. 

## Progress bar
The progress bar looks cool 😎 
<img width="788" alt="Screenshot 2022-12-13 at 18 01 55" src="https://user-images.githubusercontent.com/37387616/207397084-1366077e-6f7c-4412-b2ea-1a121968bb97.png">


Im sure a lot of things are unclear (bad names, unclear functions, etc.) so give me your worst

fixes #44
fixes #43  
^ doesn't exactly do what the issue asks, but I think it solves the main problem: the computer being a hostage to `tally` 