### PR TITLE
Upgrade packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ clap = { version = "4.0.27", features = ["derive", "cargo", "string"] }
 dotenv = "0.15.0"
 reqwest = "0.11.13"
 serde = "1.0.148"
-strip-ansi-escapes = "0.1.1"
+strip-ansi-escapes = "0.2.0"
 tokio = { version = "1.22.0", features = ["full"] }
 
-sanitize_html = { version = "0.7.0", optional = true }
-criterion = { version = "0.3", optional = true }
+sanitize_html = { version = "0.8.0", optional = true }
+criterion = { version = "0.5.1", optional = true }
 indicatif = { version = "0.17.2", optional = true }
 duct = "0.13.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,18 @@ chrono = "0.4.23"
 clap = { version = "4.0.27", features = ["derive", "cargo", "string"] }
 dotenv = "0.15.0"
 reqwest = "0.11.13"
-sanitize_html = "0.7.0"
 serde = "1.0.148"
 strip-ansi-escapes = "0.1.1"
 tokio = { version = "1.22.0", features = ["full"] }
 
+sanitize_html = { version = "0.7.0", optional = true }
 criterion = { version = "0.3", optional = true }
 indicatif = { version = "0.17.2", optional = true }
 duct = "0.13.6"
 
 
 [features]
-default = ["bench", "tally"]
+default = ["bench", "tally", "submit"]
 bench = ["criterion"]
 tally = ["indicatif"]
+submit = ["sanitize_html"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,9 +3,11 @@ pub enum AocError
     TokenError,
     ReqwestError(reqwest::Error),
     DownloadError(String),
+    #[cfg(feature = "submit")]
     SanitizeHtml,
     ParseStdout,
     InvalidRunDay,
+    #[cfg(feature = "submit")]
     InvalidSubmitDay,
     InvalidYear,
     ParseIntError,
@@ -41,9 +43,11 @@ macro_rules! impl_print {
                 {
                     AocError::TokenError => write!(f, "Could not find AOC_TOKEN to download input or submit"),
                     AocError::ReqwestError(e) => write!(f, "reqwest error: {}", e),
+                    #[cfg(feature = "submit")]
                     AocError::SanitizeHtml => write!(f, "Error on sanitizing answer"),
                     AocError::ParseStdout => write!(f, "Error on getting answer from task"),
                     AocError::InvalidRunDay => write!(f, "Day must be between 1 and 25"),
+                    #[cfg(feature = "submit")]
                     AocError::InvalidSubmitDay => write!(f, "Can only submit 1 or 2"),
                     AocError::InvalidYear => write!(f, "Year must be between 2015 ..= current year"),
                     AocError::ParseIntError => write!(f, "Error parsing to number"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<(), AocError>
                         .default_value(std::env::var("RUSTFLAGS").unwrap_or_default())
                         .allow_hyphen_values(true)
                         .help("Flags to send to rustc"),
+                    #[cfg(feature = "submit")]
                     Arg::new("submit")
                         .short('S')
                         .long("submit")

--- a/src/run.rs
+++ b/src/run.rs
@@ -4,12 +4,12 @@ use chrono::prelude::*;
 use clap::ArgMatches;
 use duct::cmd;
 
+#[cfg(feature = "submit")] use crate::util::submit::{self, get_submit_day};
 use crate::{
     error::AocError,
     util::{
         file::{cargo_path, day_path, download_input_file},
         get_day, get_year,
-        submit::{self, get_submit_day},
     },
 };
 
@@ -75,6 +75,7 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
     }
 
     // Only try to submit if the submit flag is passed
+    #[cfg(feature = "submit")]
     if let Some(submit) = get_submit_day(matches)
     {
         let year = get_year(matches)?;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,7 +4,7 @@ use crate::error::AocError;
 
 pub mod file;
 pub mod request;
-pub mod submit;
+#[cfg(feature = "submit")] pub mod submit;
 
 pub fn get_year(matches: &ArgMatches) -> Result<i32, AocError>
 {

--- a/src/util/request.rs
+++ b/src/util/request.rs
@@ -2,7 +2,6 @@ use reqwest::{
     header::{COOKIE, USER_AGENT},
     IntoUrl, Response,
 };
-use serde::Serialize;
 
 use crate::error::AocError;
 
@@ -42,10 +41,11 @@ impl AocRequest
         self.request(req).await
     }
 
+    #[cfg(feature = "submit")]
     pub async fn post<T, U>(self, url: U, form: &T) -> Result<Response, AocError>
     where
         U: IntoUrl,
-        T: Serialize + ?Sized,
+        T: serde::Serialize + ?Sized,
     {
         let req = self.client.post(url).form(form);
         self.request(req).await

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -46,7 +46,7 @@ fn get_answer(out: &str, task: &Task) -> Option<String>
 {
     let start = out.split(&format!("Task {}: ", task)).nth(1)?;
     let encoded_answer = start.split_once('\n').unwrap_or((start, "")).0;
-    let answer = strip_ansi_escapes::strip(encoded_answer).ok()?;
+    let answer = strip_ansi_escapes::strip(encoded_answer);
     String::from_utf8(answer).ok()
 }
 

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -9,7 +9,9 @@ use crate::error::AocError;
 pub fn get_submit_day(matches: &ArgMatches) -> Option<Result<Task, AocError>>
 {
     let day = matches.get_one::<String>("submit")?;
-    let Ok(day) = day.parse::<u8>() else {
+    let Ok(day) = day.parse::<u8>()
+    else
+    {
         return Some(Err(AocError::ParseIntError));
     };
 


### PR DESCRIPTION
Based of the other PR, so I will rebase this after that is merged.
I haven't tested anything, but it compiles🤷‍♂️ The API of one method actually changed from returning `Result<Vec<u8>>` to just `Vec<u8>`, so had to remove the conversion to an option and the `?`