### PR TITLE
Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ sanitize_html = { version = "0.8.0", optional = true }
 criterion = { version = "0.5.1", optional = true }
 indicatif = { version = "0.17.2", optional = true }
 duct = "0.13.6"
+thiserror = "1.0.50"
 
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,78 +1,56 @@
-use chrono::prelude::*;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
 pub enum AocError
 {
-    TokenError,
-    ReqwestError(reqwest::Error),
+    #[error("Could not find AOC_TOKEN to download input or submit")]
+    TokenError(#[from] dotenv::Error),
+
+    #[error("reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error("download error: {0}")]
     DownloadError(String),
+
     #[cfg(feature = "submit")]
+    #[error("Error on sanitizing answer")]
     SanitizeHtml,
+
+    #[error("Error on getting answer from task")]
     ParseStdout,
+
+    #[error("Day must be between 1 and 25")]
     InvalidRunDay,
+
     #[cfg(feature = "submit")]
+    #[error("Can only submit task 1 or 2")]
     InvalidSubmitDay,
+
+    #[error("Year must be between 2015 ..= current year")]
     InvalidYear,
+    #[error("Its not yet december for this year's puzzles!")]
     InvalidMonth,
-    ParseIntError,
+
+    #[error("Error parsing to number")]
+    ParseIntError(#[from] std::num::ParseIntError),
+
+    #[error("Error on getting argument")]
     ArgMatches,
-    Utf8Error,
-    StdIoErr(std::io::Error),
+
+    #[error("Error on parsing to utf-8")]
+    Utf8Error(#[from] std::str::Utf8Error),
+
+    #[error("stdio error {0}")]
+    StdIoErr(#[from] std::io::Error),
+
+    #[error("argument error {0}")]
     ArgError(String),
+
     #[cfg(feature = "tally")]
+    #[error("{0}")]
     BuildError(String),
+
     #[cfg(feature = "tally")]
+    #[error("{0}")]
     RunError(String),
 }
-
-macro_rules! impl_from_helper {
-    ($from:ty, $to: expr) => {
-        impl From<$from> for AocError
-        {
-            fn from(e: $from) -> Self
-            {
-                $to(e)
-            }
-        }
-    };
-}
-
-macro_rules! impl_print {
-    ($($from: ty),*) => {$(
-        impl $from for AocError
-        {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
-            {
-                match self
-                {
-                    AocError::TokenError => write!(f, "Could not find AOC_TOKEN to download input or submit"),
-                    AocError::ReqwestError(e) => write!(f, "reqwest error: {}", e),
-                    #[cfg(feature = "submit")]
-                    AocError::SanitizeHtml => write!(f, "Error on sanitizing answer"),
-                    AocError::ParseStdout => write!(f, "Error on getting answer from task"),
-                    AocError::InvalidRunDay => write!(f, "Day must be between 1 and 25"),
-                    #[cfg(feature = "submit")]
-                    AocError::InvalidSubmitDay => write!(f, "Can only submit 1 or 2"),
-                    AocError::InvalidYear => write!(f, "Year must be between 2015 ..= current year"),
-                    AocError::InvalidMonth => write!(f, "I's {}, but its not yet december!", Utc::now().year()),
-                    AocError::ParseIntError => write!(f, "Error parsing to number"),
-                    AocError::ArgMatches => write!(f, "Error on getting argument"),
-                    AocError::StdIoErr(e) => write!(f, "{}", e),
-                    AocError::DownloadError(e) => write!(f, "{}", e),
-                    AocError::Utf8Error => write!(f, "Error on parsing to utf-8"),
-                    AocError::ArgError(e) => write!(f, "{}", e),
-                    #[cfg(feature = "tally")]
-                    AocError::BuildError(e) => write!(f, "{}", e),
-                    #[cfg(feature = "tally")]
-                    AocError::RunError(e) => write!(f, "{}", e),
-                }
-            }
-        }
-    )*}
-}
-
-impl_from_helper!(dotenv::Error, |_| AocError::TokenError);
-impl_from_helper!(std::num::ParseIntError, |_| AocError::ParseIntError);
-impl_from_helper!(std::str::Utf8Error, |_| AocError::Utf8Error);
-impl_from_helper!(std::io::Error, |e| Self::StdIoErr(e));
-impl_from_helper!(reqwest::Error, |e| Self::ReqwestError(e));
-
-impl_print!(std::fmt::Display, std::fmt::Debug);

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum AocError
 
     #[cfg(feature = "submit")]
     #[error("Can only submit task 1 or 2")]
-    InvalidSubmitDay,
+    InvalidSubmitTask,
 
     #[error("Year must be between 2015 ..= current year")]
     InvalidYear,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use chrono::prelude::*;
 pub enum AocError
 {
     TokenError,
@@ -10,6 +11,7 @@ pub enum AocError
     #[cfg(feature = "submit")]
     InvalidSubmitDay,
     InvalidYear,
+    InvalidMonth,
     ParseIntError,
     ArgMatches,
     Utf8Error,
@@ -50,6 +52,7 @@ macro_rules! impl_print {
                     #[cfg(feature = "submit")]
                     AocError::InvalidSubmitDay => write!(f, "Can only submit 1 or 2"),
                     AocError::InvalidYear => write!(f, "Year must be between 2015 ..= current year"),
+                    AocError::InvalidMonth => write!(f, "I's {}, but its not yet december!", Utc::now().year()),
                     AocError::ParseIntError => write!(f, "Error parsing to number"),
                     AocError::ArgMatches => write!(f, "Error on getting argument"),
                     AocError::StdIoErr(e) => write!(f, "{}", e),

--- a/src/run.rs
+++ b/src/run.rs
@@ -36,10 +36,16 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
         let year = get_year(matches)?;
         let current_year = Utc::now().year();
         let current_month = Utc::now().month();
-        if year < 2015 || year > current_year || (year == current_year && current_month < 12)
+
+        if year < 2015 || year > current_year
         {
             return Err(AocError::InvalidYear);
         }
+        if year == current_year && current_month < 12
+        {
+            return Err(AocError::InvalidMonth);
+        }
+
         download_input_file(day, year, &dir).await?;
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use clap::ArgMatches;
 use duct::cmd;
 
-#[cfg(feature = "submit")] use crate::util::submit::{self, get_submit_day};
+#[cfg(feature = "submit")] use crate::util::submit::{self, get_submit_task};
 use crate::{
     error::AocError,
     util::{
@@ -82,7 +82,7 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
 
     // Only try to submit if the submit flag is passed
     #[cfg(feature = "submit")]
-    if let Some(submit) = get_submit_day(matches)
+    if let Some(submit) = get_submit_task(matches)
     {
         let year = get_year(matches)?;
         match submit

--- a/src/run.rs
+++ b/src/run.rs
@@ -82,18 +82,11 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
 
     // Only try to submit if the submit flag is passed
     #[cfg(feature = "submit")]
-    if let Some(submit) = get_submit_task(matches)
+    if let Some(task) = get_submit_task(matches).transpose()?
     {
         let year = get_year(matches)?;
-        match submit
-        {
-            Ok(task) => match submit::submit(&out, &task, day, year).await
-            {
-                Ok(output) => println!("Task {}: {}", task, output),
-                Err(e) => println!("Error submitting task {}: {}", task, e),
-            },
-            Err(e) => println!("Error: {}", e),
-        }
+        let output = submit::submit(&out, task, day, year).await?;
+        println!("Task {}: {}", task, output);
     }
     Ok(())
 }

--- a/src/util/request.rs
+++ b/src/util/request.rs
@@ -28,8 +28,9 @@ impl AocRequest
 
     async fn request(self, req: reqwest::RequestBuilder) -> Result<Response, AocError>
     {
+        let token = self.get_token()?.replace("session=", "");
         Ok(req
-            .header(COOKIE, format!("session={}", self.get_token()?))
+            .header(COOKIE, format!("session={}", token))
             .header(USER_AGENT, AocRequest::AOC_USER_AGENT)
             .send()
             .await?)

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -8,12 +8,12 @@ use crate::error::AocError;
 
 pub fn get_submit_day(matches: &ArgMatches) -> Option<Result<Task, AocError>>
 {
-    let day = matches.get_one::<String>("submit")?;
-    let Ok(day) = day.parse::<u8>()
-    else
+    let day = matches.get_one::<String>("submit")?.parse::<u8>();
+    if let Err(e) = day
     {
-        return Some(Err(AocError::ParseIntError));
-    };
+        return Some(Err(e.into()));
+    }
+    let day = day.unwrap();
 
     match day
     {

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -6,20 +6,18 @@ use sanitize_html::rules::predefined::DEFAULT;
 use super::request::AocRequest;
 use crate::error::AocError;
 
-pub fn get_submit_day(matches: &ArgMatches) -> Option<Result<Task, AocError>>
+pub fn get_submit_task(matches: &ArgMatches) -> Option<Result<Task, AocError>>
 {
-    let day = matches.get_one::<String>("submit")?.parse::<u8>();
-    if let Err(e) = day
+    let task = matches.get_one::<String>("submit")?.parse::<u8>();
+    if let Err(e) = task
     {
         return Some(Err(e.into()));
     }
-    let day = day.unwrap();
-
-    match day
+    match task.unwrap()
     {
         1 => Some(Ok(Task::One)),
         2 => Some(Ok(Task::Two)),
-        _ => Some(Err(AocError::InvalidSubmitDay)),
+        _ => Some(Err(AocError::InvalidSubmitTask)),
     }
 }
 

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -69,7 +69,5 @@ pub async fn submit(output: &str, task: &Task, day: u32, year: i32) -> Result<St
     let res = AocRequest::new().post(&url, &form).await?;
 
     let text = &res.text().await?;
-    let parsed_output = parse_and_sanitize_output(text).ok_or(AocError::SanitizeHtml)?;
-
-    Ok(parsed_output)
+    parse_and_sanitize_output(text).ok_or(AocError::SanitizeHtml)
 }

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -21,7 +21,7 @@ pub fn get_submit_task(matches: &ArgMatches) -> Option<Result<Task, AocError>>
     }
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Clone, Copy)]
 pub enum Task
 {
     One,
@@ -40,7 +40,7 @@ impl std::fmt::Display for Task
     }
 }
 
-fn get_answer(out: &str, task: &Task) -> Option<String>
+fn get_answer(out: &str, task: Task) -> Option<String>
 {
     let start = out.split(&format!("Task {}: ", task)).nth(1)?;
     let encoded_answer = start.split_once('\n').unwrap_or((start, "")).0;
@@ -56,13 +56,13 @@ fn parse_and_sanitize_output(output: &str) -> Option<String>
     sanitize_html::sanitize_str(&DEFAULT, body).ok()
 }
 
-pub async fn submit(output: &str, task: &Task, day: u32, year: i32) -> Result<String, AocError>
+pub async fn submit(output: &str, task: Task, day: u32, year: i32) -> Result<String, AocError>
 {
     let answer = get_answer(output, task).ok_or(AocError::ParseStdout)?;
     let url = format!("https://adventofcode.com/{}/day/{}/answer", year, day);
 
     let mut form = HashMap::new();
-    form.insert("level", if task == &Task::One { 1 } else { 2 }.to_string());
+    form.insert("level", if task == Task::One { 1 } else { 2 }.to_string());
     form.insert("answer", answer);
     let res = AocRequest::new().post(&url, &form).await?;
 


### PR DESCRIPTION
# changes :dog2: 
* accept both token formats
    - session={token}
    - {token}
 * use `thiserror` for `AocError`
 * add `InvalidMonth` error variant
 * simplify some Result logic
 * Add Clone and Copy for `Task`, dont need to pass a reference to such a simple enum 