### PR TITLE
add: unit variable support

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -9,7 +9,7 @@ use crate::{
     error::AocError,
     util::{
         file::{cargo_path, day_path, download_input_file},
-        get_day, get_year,
+        get_day, get_time_symbol, get_year,
     },
 };
 
@@ -70,10 +70,11 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
     let mut lines = reader.lines();
 
     let mut out = String::new();
+    let unit = get_time_symbol();
     while let Some(Ok(line)) = lines.next()
     {
         println!("{}", line);
-        if line.contains("ms)\tTask")
+        if line.contains(&format!("{unit})\tTask"))
         {
             out.push_str(&line);
             out.push('\n');

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -31,3 +31,16 @@ pub fn get_day(matches: &ArgMatches) -> Result<u32, AocError>
         Ok(day)
     }
 }
+
+pub fn get_time_symbol() -> String
+{
+    let sym = std::env::var("TASKUNIT").unwrap_or("ms".to_owned());
+    if sym == "us"
+    {
+        "μs".to_owned()
+    }
+    else
+    {
+        sym
+    }
+}

--- a/template/template.rs
+++ b/template/template.rs
@@ -35,17 +35,27 @@ where
 {
     let t = std::time::Instant::now();
     let res = f(arg);
-    let elapsed = t.elapsed().as_millis();
+    let elapsed = t.elapsed();
+    let fmt = std::env::var("TASKUNIT").unwrap_or("ms".to_owned());
+
+    let (u, elapsed) = match fmt.as_str()
+    {
+        "ms" => ("ms", elapsed.as_millis()),
+        "ns" => ("ns", elapsed.as_nanos()),
+        "us" => ("μs", elapsed.as_micros()),
+        "s" => ("s", elapsed.as_secs() as u128),
+        _ => panic!("unsupported time format"),
+    };
 
     match task
     {
         Task::One =>
         {
-            println!("({}ms)\tTask one: \x1b[0;34;34m{}\x1b[0m", elapsed, res);
+            println!("({}{u})\tTask one: \x1b[0;34;34m{}\x1b[0m", elapsed, res);
         },
         Task::Two =>
         {
-            println!("({}ms)\tTask two: \x1b[0;33;10m{}\x1b[0m", elapsed, res);
+            println!("({}{u})\tTask two: \x1b[0;33;10m{}\x1b[0m", elapsed, res);
         },
     };
 }


### PR DESCRIPTION
# context :bird: 
I added this to my/the template 
```rs
let fmt = std::env::var("TASKUNIT").unwrap_or("ms".to_owned());
let (u, elapsed) = match fmt.as_str() {
    "ms" => ("ms", elapsed.as_millis()),
    "ns" => ("ns", elapsed.as_nanos()),
    "us" => ("μs", elapsed.as_micros()),
    "s" => ("s", elapsed.as_secs() as u128),
    _ => panic!("unsupported time format"),
};
```

So that I can run `TASKUNIT=us cargo aoc run` and get the microsecond performance, for instance
 

This code breaks the `tally`, and , more importantly, `run -S 1|2` command, so I had to fix that

Let me know what you think