### PR TITLE
Assert

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -1,0 +1,62 @@
+use crate::{
+    error::AocError,
+    util::{get_day_title_and_answers, parse_get_answers, Task},
+};
+
+pub fn assert_print(expected: &str, actual: &str, task: Task)
+{
+    if expected == actual
+    {
+        println!("Task {}: \x1b[0;32mok\x1b[0m", task);
+    }
+    else
+    {
+        println!(
+            "Task {}: \x1b[0;31mFAILED\x1b[0m
+    expected: `{}`,
+    actual: `{}`",
+            task, expected, actual
+        )
+    }
+}
+
+pub async fn assert_answer(out: &str, day: u32, year: i32) -> Result<(), AocError>
+{
+    let info = get_day_title_and_answers(day, year as u32).await?;
+    let (p1, p2) = parse_get_answers(out);
+
+    match (p1, p2, info.part1_answer, info.part2_answer)
+    {
+        (Some(p1), Some(p2), Some(a1), Some(a2)) =>
+        {
+            assert_print(&a1, &p1, Task::One);
+            assert_print(&a2, &p2, Task::Two);
+        },
+        (Some(p1), None, Some(a1), Some(_)) =>
+        {
+            assert_print(&a1, &p1, Task::One);
+            println!("Couldn't verify answer for part 2");
+        },
+        (Some(p1), _, Some(a1), None) =>
+        {
+            assert_print(&a1, &p1, Task::One);
+            println!("You haven't completed part 2");
+        },
+        (None, Some(p2), Some(_), Some(a2)) =>
+        {
+            println!("Couldn't verify answer for part 1");
+            assert_print(&a2, &p2, Task::Two);
+        },
+        (None, None, ..) => println!("You haven't completed the day yet..."),
+
+        // Assumes that it is impossible for it to _not_ find the submitted answer for part 1, but
+        // then find the submitted answer for part 2
+        (_, _, None, _) => println!("Coulnd't find the submitted answers..."),
+
+        (None, Some(_), Some(_), None) => println!(
+            "Only found answer for part 2, but could only find submitted answer for part 1"
+        ),
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), AocError>
                         .action(clap::ArgAction::SetTrue)
                         .help("Run the day with the \"test\" file"),
                     Arg::new("assert")
-                        .short('a') // TODO: Should we have a short flag? If so, is `a` ok?
+                        .short('a')
                         .long("assert")
                         .required(false)
                         .action(clap::ArgAction::SetTrue)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use chrono::Datelike;
 use clap::{builder::OsStr, Arg, Command};
 use error::AocError;
+mod assert;
 #[cfg(feature = "bench")] mod bench;
 mod clippy;
 mod error;
@@ -68,6 +69,12 @@ async fn main() -> Result<(), AocError>
                         .required(false)
                         .action(clap::ArgAction::SetTrue)
                         .help("Run the day with the \"test\" file"),
+                    Arg::new("assert")
+                        .short('a') // TODO: Should we have a short flag? If so, is `a` ok?
+                        .long("assert")
+                        .required(false)
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Asserts that the answers are still correct after submitting"),
                     Arg::new("compiler-flags")
                         .short('C')
                         .long("compiler-flags")

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), AocError>
 {
     dotenv::dotenv().ok();
     let mut cmd = Command::new("cargo-aoc")
-        .author("Sebastian, seblyng98@gmail.com")
+        .author("Sebastian, sebastian@lyngjohansen.com")
         .author("Sivert, sivert-joh@hotmail.com")
         .arg(Arg::new("dummy").hide(true))
         .subcommand(

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,6 +6,7 @@ use duct::cmd;
 
 #[cfg(feature = "submit")] use crate::util::submit::{self, get_submit_task};
 use crate::{
+    assert::assert_answer,
     error::AocError,
     util::{
         file::{cargo_path, day_path, download_input_file},
@@ -79,6 +80,12 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
             out.push_str(&line);
             out.push('\n');
         }
+    }
+
+    if matches.get_flag("assert")
+    {
+        let year = get_year(matches)?;
+        assert_answer(&out, day, year).await?;
     }
 
     // Only try to submit if the submit flag is passed

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,10 +1,36 @@
+use std::path::PathBuf;
+
 use clap::ArgMatches;
 
+use self::{
+    file::{cargo_path, day_path},
+    request::AocRequest,
+};
 use crate::error::AocError;
 
 pub mod file;
 pub mod request;
 #[cfg(feature = "submit")] pub mod submit;
+
+#[derive(Eq, PartialEq, Clone, Copy)]
+pub enum Task
+{
+    One,
+    Two,
+}
+
+impl std::fmt::Display for Task
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+    {
+        match self
+        {
+            Task::One => write!(f, "one"),
+            Task::Two => write!(f, "two"),
+        }
+    }
+}
+
 
 pub fn get_year(matches: &ArgMatches) -> Result<i32, AocError>
 {
@@ -43,4 +69,99 @@ pub fn get_time_symbol() -> String
     {
         sym
     }
+}
+
+#[derive(Debug)]
+pub struct AocInfo
+{
+    pub day:          u32,
+    pub year:         u32,
+    pub title:        String,
+    pub part1_answer: Option<String>,
+    pub part2_answer: Option<String>,
+}
+
+pub async fn get_day_title_and_answers(day: u32, year: u32) -> Result<AocInfo, AocError>
+{
+    if let Ok(cache) = read_cache_answers(day, year).await
+    {
+        return Ok(cache);
+    }
+
+    let url = format!("https://adventofcode.com/{}/day/{}", year, day);
+
+    let res = AocRequest::new().get(&url).await?;
+
+    let text = res.text().await?;
+
+    let h2 = "<h2>--- ";
+    let idx1 = text.find(h2).unwrap() + h2.len();
+    let idx2 = text[idx1..].find(" ---</h2>").unwrap();
+    let (_, title) = text[idx1..idx1 + idx2].split_once(": ").unwrap();
+
+    let search = "Your puzzle answer was <code>";
+    let mut iter = text.lines().filter(|&line| line.contains(search)).map(|line| {
+        let code_end = "</code>";
+        let idx = line.find(search).unwrap() + search.len();
+        let end = line[idx..].find(code_end).unwrap();
+
+        line[idx..idx + end].to_owned()
+    });
+    let a1 = iter.next();
+    let a2 = iter.next();
+
+    let info = AocInfo {
+        day,
+        year,
+        title: title.to_owned(),
+        part1_answer: a1,
+        part2_answer: a2,
+    };
+
+    // Ignore possible errors during cache write
+    let _ = write_cache_answers(day, &info).await;
+
+    Ok(info)
+}
+
+pub fn parse_get_answers(output: &str) -> (Option<String>, Option<String>)
+{
+    let strip = strip_ansi_escapes::strip(output);
+    let text = std::str::from_utf8(&strip).unwrap();
+
+    let parse = |line: &str| line.split_ascii_whitespace().next_back().map(|s| s.to_string());
+    let mut iter = text.split('\n');
+    (iter.next().and_then(parse), iter.next().and_then(parse))
+}
+
+async fn get_cache_path(day: u32) -> Result<PathBuf, AocError>
+{
+    // Tries to read it from the cache before making a request
+    let path = cargo_path().await?;
+    Ok(day_path(path, day).await?.join(".answers"))
+}
+
+pub async fn write_cache_answers(day: u32, info: &AocInfo) -> Result<(), AocError>
+{
+    let path = get_cache_path(day).await?;
+    if let (Some(a1), Some(a2)) = (&info.part1_answer, &info.part2_answer)
+    {
+        tokio::fs::write(path, format!("{}\n{}\n{}", info.title, a1, a2)).await?;
+    }
+
+    Ok(())
+}
+
+pub async fn read_cache_answers(day: u32, year: u32) -> Result<AocInfo, AocError>
+{
+    let path = get_cache_path(day).await?;
+    let res = tokio::fs::read_to_string(path).await?;
+    let lines = res.lines().collect::<Vec<_>>();
+    Ok(AocInfo {
+        day,
+        year,
+        title: lines[0].to_owned(),
+        part1_answer: Some(lines[1].to_owned()),
+        part2_answer: Some(lines[2].to_owned()),
+    })
 }

--- a/src/util/request.rs
+++ b/src/util/request.rs
@@ -12,7 +12,8 @@ pub struct AocRequest
 
 impl AocRequest
 {
-    const AOC_USER_AGENT: &str = "github.com/seblj/cargo-aoc by seblyng98@gmail.com";
+    const AOC_USER_AGENT: &str =
+        "github.com/seblj/cargo-aoc by sebastian@lyngjohansen.com and sivert-joh@hotmail.com";
 
     pub fn new() -> AocRequest
     {

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -32,9 +32,7 @@ fn parse_and_sanitize_output(output: &str) -> Option<String>
 pub async fn submit(output: &str, task: Task, day: u32, year: i32) -> Result<String, AocError>
 {
     let (p1, p2) = parse_get_answers(output);
-    // TODO: I don't know what I should do here if the answer is not found
-    let answer = if task == Task::One { p1 } else { p2 }
-        .unwrap_or_else(|| panic!("Can't find the answer for part {}", task));
+    let answer = if task == Task::One { p1 } else { p2 }.ok_or(AocError::ParseStdout)?;
     let url = format!("https://adventofcode.com/{}/day/{}/answer", year, day);
 
     let mut form = HashMap::new();

--- a/src/util/submit.rs
+++ b/src/util/submit.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use clap::ArgMatches;
 use sanitize_html::rules::predefined::DEFAULT;
 
-use super::request::AocRequest;
+use super::{parse_get_answers, request::AocRequest, Task};
 use crate::error::AocError;
 
 pub fn get_submit_task(matches: &ArgMatches) -> Option<Result<Task, AocError>>
@@ -21,33 +21,6 @@ pub fn get_submit_task(matches: &ArgMatches) -> Option<Result<Task, AocError>>
     }
 }
 
-#[derive(Eq, PartialEq, Clone, Copy)]
-pub enum Task
-{
-    One,
-    Two,
-}
-
-impl std::fmt::Display for Task
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
-    {
-        match self
-        {
-            Task::One => write!(f, "one"),
-            Task::Two => write!(f, "two"),
-        }
-    }
-}
-
-fn get_answer(out: &str, task: Task) -> Option<String>
-{
-    let start = out.split(&format!("Task {}: ", task)).nth(1)?;
-    let encoded_answer = start.split_once('\n').unwrap_or((start, "")).0;
-    let answer = strip_ansi_escapes::strip(encoded_answer);
-    String::from_utf8(answer).ok()
-}
-
 fn parse_and_sanitize_output(output: &str) -> Option<String>
 {
     let start = output.find("<article><p>")?;
@@ -58,7 +31,10 @@ fn parse_and_sanitize_output(output: &str) -> Option<String>
 
 pub async fn submit(output: &str, task: Task, day: u32, year: i32) -> Result<String, AocError>
 {
-    let answer = get_answer(output, task).ok_or(AocError::ParseStdout)?;
+    let (p1, p2) = parse_get_answers(output);
+    // TODO: I don't know what I should do here if the answer is not found
+    let answer = if task == Task::One { p1 } else { p2 }
+        .unwrap_or_else(|| panic!("Can't find the answer for part {}", task));
     let url = format!("https://adventofcode.com/{}/day/{}/answer", year, day);
 
     let mut form = HashMap::new();


### PR DESCRIPTION
This adds a assert flag to the subcommand run to be able to assert that the answer is still correct, for example after a refactor.

Example use:
<img width="706" alt="image" src="https://github.com/seblj/cargo-aoc/assets/5160701/ecfca64b-99d1-422e-9d3d-e4a736e36363">
<img width="790" alt="image" src="https://github.com/seblj/cargo-aoc/assets/5160701/4e1efee4-86ed-4406-89eb-62959557515f">
<img width="704" alt="image" src="https://github.com/seblj/cargo-aoc/assets/5160701/55a3890d-2827-49f5-9e6b-ae51d4c8c2e2">
<img width="697" alt="image" src="https://github.com/seblj/cargo-aoc/assets/5160701/fa8df9c1-4810-429b-b54c-c9fb8bde6ee7">
<img width="904" alt="image" src="https://github.com/seblj/cargo-aoc/assets/5160701/c319e9b1-fec3-4070-8bb5-e7684a2b1d1b">
