### PR TITLE
Refactor template

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -54,4 +54,7 @@ pub enum AocError
     #[cfg(feature = "tally")]
     #[error("{0}")]
     RunError(String),
+
+    #[error("Setup for year already exists")]
+    SetupExists,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,6 @@ async fn main() -> Result<(), AocError>
                         .required(false)
                         .default_value(OsStr::from(chrono::Utc::now().day().to_string()))
                         .help("Day to run"),
-                    Arg::new("year")
-                        .short('y')
-                        .required(false)
-                        .default_value(OsStr::from(chrono::Utc::now().year().to_string()))
-                        .help("Year for automatic download of input if not present"),
                     Arg::new("test")
                         .short('t')
                         .long("test")

--- a/src/run.rs
+++ b/src/run.rs
@@ -84,7 +84,7 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
 
     if matches.get_flag("assert")
     {
-        let year = get_year(matches)?;
+        let year = get_year_from_root().await?;
         assert_answer(&out, day, year).await?;
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,7 +10,7 @@ use crate::{
     error::AocError,
     util::{
         file::{cargo_path, day_path, download_input_file},
-        get_day, get_time_symbol, get_year,
+        get_day, get_time_symbol, get_year_from_root,
     },
 };
 
@@ -34,7 +34,7 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
 
     if !dir.join("input").exists()
     {
-        let year = get_year(matches)?;
+        let year = get_year_from_root().await?;
         let current_year = Utc::now().year();
         let current_month = Utc::now().month();
 
@@ -92,7 +92,7 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError>
     #[cfg(feature = "submit")]
     if let Some(task) = get_submit_task(matches).transpose()?
     {
-        let year = get_year(matches)?;
+        let year = get_year_from_root().await?;
         let output = submit::submit(&out, task, day, year).await?;
         println!("Task {}: {}", task, output);
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,12 +4,17 @@ use crate::{error::AocError, util::get_year};
 
 async fn setup_template_project(year: i32) -> Result<(), AocError>
 {
-    tokio::process::Command::new("cargo")
+    let res = tokio::process::Command::new("cargo")
         .args(["new", &format!("year_{}", year)])
         .output()
         .await?;
 
     let template = format!("{}/template/template.rs", env!("CARGO_MANIFEST_DIR"));
+    if !res.status.success()
+    {
+        return Err(AocError::SetupExists);
+    }
+
     for i in 1..=25
     {
         let dir = format!("year_{year}/src/bin/day_{:0>2}", i);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,6 +7,11 @@ use crate::error::AocError;
 
 async fn setup_template_project(year: i32) -> Result<(), AocError>
 {
+    if Path::new(&format!("{year}")).exists()
+    {
+        return Err(AocError::SetupExists);
+    }
+
     let res = tokio::process::Command::new("cargo")
         .args(["new", &format!("year_{}", year)])
         .output()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -17,24 +17,26 @@ async fn setup_template_project(year: i32) -> Result<(), AocError>
         return Err(AocError::SetupExists);
     }
 
+    tokio::fs::rename(format!("year_{year}"), format!("{year}")).await?;
+
     let template_dir = format!("{}/template", env!("CARGO_MANIFEST_DIR"));
     let bins = tokio::fs::read(Path::new(&template_dir).join("Cargo.toml.template")).await?;
 
     OpenOptions::new()
         .append(true)
-        .open(format!("year_{}/Cargo.toml", year))
+        .open(format!("{}/Cargo.toml", year))
         .await?
         .write_all(&bins)
         .await?;
 
     for i in 1..=25
     {
-        let dir = format!("year_{year}/day_{:0>2}", i);
+        let dir = format!("{year}/src/day_{:0>2}", i);
         tokio::fs::create_dir_all(&dir).await?;
         tokio::fs::copy(Path::new(&template_dir).join("template.rs"), format!("{dir}/main.rs"))
             .await?;
     }
-    tokio::fs::remove_dir_all(format!("year_{year}/src")).await?;
+    tokio::fs::remove_file(format!("{year}/src/main.rs")).await?;
     Ok(())
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use clap::ArgMatches;
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 
-use crate::{error::AocError, util::get_year};
+use crate::error::AocError;
 
 async fn setup_template_project(year: i32) -> Result<(), AocError>
 {
@@ -56,6 +56,19 @@ async fn get_session_token() -> Result<(), AocError>
         }
     }
     Ok(())
+}
+
+fn get_year(matches: &ArgMatches) -> Result<i32, AocError>
+{
+    let year = matches.get_one::<String>("year").ok_or(AocError::ArgMatches)?;
+    if year.chars().count() == 2
+    {
+        Ok(format!("20{}", year).parse()?)
+    }
+    else
+    {
+        Ok(year.parse()?)
+    }
 }
 
 pub async fn setup(args: &ArgMatches) -> Result<(), AocError>

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    io::{Error, ErrorKind},
+    path::PathBuf,
+};
 
 use clap::ArgMatches;
 
@@ -32,9 +35,16 @@ impl std::fmt::Display for Task
 }
 
 
-pub fn get_year(matches: &ArgMatches) -> Result<i32, AocError>
+pub async fn get_year_from_root() -> Result<i32, AocError>
 {
-    let year = matches.get_one::<String>("year").ok_or(AocError::ArgMatches)?;
+    let root = cargo_path().await?;
+    let year = root
+        .file_name()
+        .ok_or_else(|| {
+            AocError::StdIoErr(Error::new(ErrorKind::NotFound, "could not find Cargo.toml file"))
+        })?
+        .to_string_lossy();
+
     if year.chars().count() == 2
     {
         Ok(format!("20{}", year).parse()?)

--- a/src/util/request.rs
+++ b/src/util/request.rs
@@ -12,7 +12,7 @@ pub struct AocRequest
 
 impl AocRequest
 {
-    const AOC_USER_AGENT: &str =
+    const AOC_USER_AGENT: &'static str =
         "github.com/seblj/cargo-aoc by sebastian@lyngjohansen.com and sivert-joh@hotmail.com";
 
     pub fn new() -> AocRequest

--- a/template/Cargo.toml.template
+++ b/template/Cargo.toml.template
@@ -1,0 +1,99 @@
+[[bin]]
+name = "day_01"
+path = "day_01/main.rs"
+
+[[bin]]
+name = "day_02"
+path = "day_02/main.rs"
+
+[[bin]]
+name = "day_03"
+path = "day_03/main.rs"
+
+[[bin]]
+name = "day_04"
+path = "day_04/main.rs"
+
+[[bin]]
+name = "day_05"
+path = "day_05/main.rs"
+
+[[bin]]
+name = "day_06"
+path = "day_06/main.rs"
+
+[[bin]]
+name = "day_07"
+path = "day_07/main.rs"
+
+[[bin]]
+name = "day_08"
+path = "day_08/main.rs"
+
+[[bin]]
+name = "day_09"
+path = "day_09/main.rs"
+
+[[bin]]
+name = "day_10"
+path = "day_10/main.rs"
+
+[[bin]]
+name = "day_11"
+path = "day_11/main.rs"
+
+[[bin]]
+name = "day_12"
+path = "day_12/main.rs"
+
+[[bin]]
+name = "day_13"
+path = "day_13/main.rs"
+
+[[bin]]
+name = "day_14"
+path = "day_14/main.rs"
+
+[[bin]]
+name = "day_15"
+path = "day_15/main.rs"
+
+[[bin]]
+name = "day_16"
+path = "day_16/main.rs"
+
+[[bin]]
+name = "day_17"
+path = "day_17/main.rs"
+
+[[bin]]
+name = "day_18"
+path = "day_18/main.rs"
+
+[[bin]]
+name = "day_19"
+path = "day_19/main.rs"
+
+[[bin]]
+name = "day_20"
+path = "day_20/main.rs"
+
+[[bin]]
+name = "day_21"
+path = "day_21/main.rs"
+
+[[bin]]
+name = "day_22"
+path = "day_22/main.rs"
+
+[[bin]]
+name = "day_23"
+path = "day_23/main.rs"
+
+[[bin]]
+name = "day_24"
+path = "day_24/main.rs"
+
+[[bin]]
+name = "day_25"
+path = "day_25/main.rs"

--- a/template/Cargo.toml.template
+++ b/template/Cargo.toml.template
@@ -1,99 +1,99 @@
 [[bin]]
 name = "day_01"
-path = "day_01/main.rs"
+path = "src/day_01/main.rs"
 
 [[bin]]
 name = "day_02"
-path = "day_02/main.rs"
+path = "src/day_02/main.rs"
 
 [[bin]]
 name = "day_03"
-path = "day_03/main.rs"
+path = "src/day_03/main.rs"
 
 [[bin]]
 name = "day_04"
-path = "day_04/main.rs"
+path = "src/day_04/main.rs"
 
 [[bin]]
 name = "day_05"
-path = "day_05/main.rs"
+path = "src/day_05/main.rs"
 
 [[bin]]
 name = "day_06"
-path = "day_06/main.rs"
+path = "src/day_06/main.rs"
 
 [[bin]]
 name = "day_07"
-path = "day_07/main.rs"
+path = "src/day_07/main.rs"
 
 [[bin]]
 name = "day_08"
-path = "day_08/main.rs"
+path = "src/day_08/main.rs"
 
 [[bin]]
 name = "day_09"
-path = "day_09/main.rs"
+path = "src/day_09/main.rs"
 
 [[bin]]
 name = "day_10"
-path = "day_10/main.rs"
+path = "src/day_10/main.rs"
 
 [[bin]]
 name = "day_11"
-path = "day_11/main.rs"
+path = "src/day_11/main.rs"
 
 [[bin]]
 name = "day_12"
-path = "day_12/main.rs"
+path = "src/day_12/main.rs"
 
 [[bin]]
 name = "day_13"
-path = "day_13/main.rs"
+path = "src/day_13/main.rs"
 
 [[bin]]
 name = "day_14"
-path = "day_14/main.rs"
+path = "src/day_14/main.rs"
 
 [[bin]]
 name = "day_15"
-path = "day_15/main.rs"
+path = "src/day_15/main.rs"
 
 [[bin]]
 name = "day_16"
-path = "day_16/main.rs"
+path = "src/day_16/main.rs"
 
 [[bin]]
 name = "day_17"
-path = "day_17/main.rs"
+path = "src/day_17/main.rs"
 
 [[bin]]
 name = "day_18"
-path = "day_18/main.rs"
+path = "src/day_18/main.rs"
 
 [[bin]]
 name = "day_19"
-path = "day_19/main.rs"
+path = "src/day_19/main.rs"
 
 [[bin]]
 name = "day_20"
-path = "day_20/main.rs"
+path = "src/day_20/main.rs"
 
 [[bin]]
 name = "day_21"
-path = "day_21/main.rs"
+path = "src/day_21/main.rs"
 
 [[bin]]
 name = "day_22"
-path = "day_22/main.rs"
+path = "src/day_22/main.rs"
 
 [[bin]]
 name = "day_23"
-path = "day_23/main.rs"
+path = "src/day_23/main.rs"
 
 [[bin]]
 name = "day_24"
-path = "day_24/main.rs"
+path = "src/day_24/main.rs"
 
 [[bin]]
 name = "day_25"
-path = "day_25/main.rs"
+path = "src/day_25/main.rs"


### PR DESCRIPTION
This adds a couple of changes.

First, it changes the template to remove the bin and src folder. Instead it appends to Cargo.toml on the path to the binaries for the respective days. It might be controversial to remove the src folder. I am not sure if I want to do that or not, but I at least want to remove the bin folder.

I also added a check to make sure that we don't override a project if it already exists.

There is also one breaking change here. Removal of the year argument to run. However, I think calculating it from the directory is better, as it may lead to less undefined behaviour. Currently, if I have a folder `year_2020`, and I run `cargo aoc run -d 1` inside that folder, it will run the correct day from that year. However, since I forgot to add the `year` flag, it will actually download the input file from 2023 (current year)!. This changes that behaviour to correctly parese the folder name to download the correct input