### PR TITLE
add subcommand for test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod error;
 mod run;
 mod setup;
 #[cfg(feature = "tally")] mod tally;
+mod test;
 mod token;
 mod util;
 
@@ -88,6 +89,13 @@ async fn main() -> Result<(), AocError>
                 .about("Runs the given day"),
         )
         .subcommand(
+            clap::command!("test").args([Arg::new("day")
+                .short('d')
+                .required(false)
+                .default_value(OsStr::from(chrono::Utc::now().day().to_string()))
+                .help("Day to run tests for")]),
+        )
+        .subcommand(
             Command::new("token")
                 .about("Get or set the session token used to communicate with the AOC servers")
                 .arg_required_else_help(true)
@@ -144,6 +152,7 @@ async fn main() -> Result<(), AocError>
             setup::setup(matches).await.expect("Couldn't setup project properly")
         },
         Some(("run", matches)) => run::run(matches).await?,
+        Some(("test", matches)) => test::test(matches).await?,
         Some(("token", matches)) => token::token(matches).await?,
         Some(("clippy", matches)) => clippy::clippy(matches).await?,
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,34 @@
+use std::io::{BufRead, BufReader};
+
+use clap::ArgMatches;
+use duct::cmd;
+
+use crate::{error::AocError, util::get_day};
+
+pub async fn test(matches: &ArgMatches) -> Result<(), AocError>
+{
+    let day = get_day(matches)?;
+
+    let reader = cmd!(
+        "cargo",
+        "test",
+        "--color",
+        "always",
+        "--bin",
+        format!("day_{:02}", day).as_str(),
+        "--",
+        "--color",
+        "always"
+    )
+    .stderr_to_stdout()
+    .reader()?;
+
+    let reader = BufReader::new(reader);
+    let mut lines = reader.lines();
+
+    while let Some(Ok(line)) = lines.next()
+    {
+        println!("{}", line);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Add a subcommand to run tests. Accepts the same argument as run for day with the same default.

We should probably change the default for this as well when/if we close this #60 as completed

Closes #61 