### PR TITLE
update(assert): only display part one on day 25

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -57,6 +57,10 @@ pub async fn assert_answer(out: &str, day: u32, year: i32) -> Result<(), AocErro
             );
             assert_print_equal(&a2, &p2, Task::Two);
         },
+        (Some(p1), _, Some(a1), None) if day == 25 =>
+        {
+            assert_print_equal(&a1, &p1, Task::One);
+        },
         (Some(p1), _, Some(a1), None) =>
         {
             assert_print_equal(&a1, &p1, Task::One);


### PR DESCRIPTION
There is only one task at day 25, and therefore only one task to assert. It should look like this
```
(0ms)   Task one: 2-212-2---=00-1--102
Task one: ok
```

But it currently looks like this
```
(0ms)   Task one: 2-212-2---=00-1--102
Task one: ok
Task two: FAILED
    `Have you completed it?`
```

This PR fixes this