### PR TITLE
Add tally --table

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -46,14 +46,6 @@ pub enum AocError {
     #[error("argument error {0}")]
     ArgError(String),
 
-    #[cfg(feature = "tally")]
-    #[error("{0}")]
-    BuildError(String),
-
-    #[cfg(feature = "tally")]
-    #[error("{0}")]
-    RunError(String),
-
     #[error("Setup for year already exists")]
     SetupExists,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,13 +121,20 @@ async fn main() -> Result<(), AocError> {
             Command::new("tally")
                 .about(
                     "Tallies the  performance of each day and displays information about the \
-                     performance",
+                        performance",
                 )
                 .arg(
                     Arg::new("runs")
                         .long("num-runs")
                         .help("Number of runs")
                         .default_value("10"),
+                )
+                .arg(
+                    Arg::new("table")
+                        .long("table")
+                        .required(false)
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Display day info in a nice table"),
                 ),
         );
     }

--- a/src/tally.rs
+++ b/src/tally.rs
@@ -376,10 +376,11 @@ fn print_table(days: Vec<Result<BuildRes, Error>>, year: usize) {
     let part2_header_len = max_part2_len + 8 + max_part2_time_len;
 
     let max_total_len = max_name_len + part1_header_len + part2_header_len + 5;
+    let title_length = max_total_len - 2;
 
     println!("╔{}╗", "═".repeat(max_total_len + 3));
     println!(
-        "║ {:^max_total_len$}  ║",
+        "║ {:^title_length$}  ║",
         format!("🦀 Advent of Code {year} 🦀")
     );
     println!(

--- a/src/tally.rs
+++ b/src/tally.rs
@@ -1,13 +1,15 @@
-use std::{path::PathBuf, process::Output};
+use std::{path::PathBuf, process::Command};
 
 use clap::ArgMatches;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use tokio::task::JoinSet;
+use tokio::runtime::Runtime;
 
 use crate::{
     error::AocError,
-    util::{file::*, get_time_symbol},
+    util::{file::*, get_day_title_and_answers, get_time_symbol, get_year_from_root},
 };
+
+use crate::util::tally_util::*;
 
 // Helper function to:
 // 1. iterate over a collection
@@ -35,31 +37,6 @@ where
     })
 }
 
-async fn days() -> Result<(Vec<(PathBuf, u32)>, Vec<u32>), AocError> {
-    let path = cargo_path().await?;
-
-    let mut set = JoinSet::new();
-    for day in 1..=25 {
-        let path = path.clone();
-        set.spawn(async move {
-            let path = day_path(path, day).await;
-            (path, day)
-        });
-    }
-
-    let mut have = Vec::new();
-    let mut dont_have = Vec::new();
-    while let Some(Ok(res)) = set.join_next().await {
-        // The day path exists
-        match res {
-            (Ok(path), day) => have.push((path, day)),
-            (_, day) => dont_have.push(day),
-        }
-    }
-
-    Ok((have, dont_have))
-}
-
 fn get_progressbar(len: u64) -> ProgressBar {
     let sty = ProgressStyle::with_template(
         "[{elapsed_precise}] {msg}... {bar:40.cyan/blue} {pos:>7}/{len:7}",
@@ -70,138 +47,13 @@ fn get_progressbar(len: u64) -> ProgressBar {
     ProgressBar::new(len).with_style(sty)
 }
 
-async fn build_days(cargo_folder: PathBuf, days: &[(PathBuf, u32)]) -> Result<Vec<u32>, AocError> {
-    let progress = get_progressbar(days.len() as u64);
-    progress.set_message("compiling");
-
-    let res: Result<(), AocError> = thread_exec(days, |(_path, day)| {
-        let bin = format!("day_{:02}", *day);
-        let res = std::process::Command::new("cargo")
-            .args(["build", "--release", "--bin", &bin])
-            .output()?;
-
-        progress.inc(1);
-        if !res.status.success() {
-            Err(AocError::BuildError(bin))
-        } else {
-            Ok(())
-        }
-    });
-    res?;
-
-    progress.reset();
-    progress.set_message("verifying days");
-
-    let unimpls: Vec<Option<u32>> = thread_exec(days, |(pb, day)| {
-        let day = *day;
-        let bin = format!("day_{:02}", day);
-        let mut target = cargo_folder.clone();
-        target.push("target/release");
-        target.push(&bin);
-        let progress = progress.clone();
-
-        let res = match std::process::Command::new(target).current_dir(pb).output() {
-            Ok(res) => {
-                // collect all 'unimplemented' days
-                parse_get_times(res).map_err(|_| day).err()
-            }
-            Err(_) => Some(day),
-        };
-        progress.inc(1);
-        res
-    });
-    Ok(unimpls.into_iter().flatten().collect())
-}
-
-fn parse_get_times(output: Output) -> Result<(usize, Option<usize>), AocError> {
-    let unit = get_time_symbol();
-    let parse = |line: &str| -> Result<usize, AocError> {
-        let start = line.find('(').ok_or(AocError::ParseStdout)?;
-        let stop = line
-            .find(&format!("{unit})"))
-            .ok_or(AocError::ParseStdout)?;
-        Ok(line[start + 1..stop].parse().unwrap())
-    };
-    let text = std::str::from_utf8(&output.stdout).unwrap();
-    let mut iter = text.split('\n');
-    let p1 = parse(iter.next().unwrap())?;
-    let p2 = iter.next().and_then(|n| parse(n).ok());
-
-    Ok((p1, p2))
-}
-
-fn run_day(
-    cargo_folder: PathBuf,
-    day: &(PathBuf, u32),
+fn print_info(
+    days: Vec<(usize, (usize, Option<usize>))>,
+    not_done: Vec<usize>,
     number_of_runs: usize,
-    progress: ProgressBar,
-) -> Result<(usize, Option<usize>), AocError> {
-    let bin = format!("day_{:02}", day.1);
-    let mut target = cargo_folder;
-    target.push("target/release");
-    target.push(&bin);
-    let mut vec = Vec::with_capacity(number_of_runs);
-
-    for _ in 0..number_of_runs {
-        let dir = &day.0;
-        let res = std::process::Command::new(&target)
-            .current_dir(dir)
-            .envs(std::env::vars())
-            .output()?;
-        if !res.status.success() {
-            return Err(AocError::RunError(format!("Error running day {}", day.1)));
-        }
-        progress.inc(1);
-        vec.push(parse_get_times(res)?);
-    }
-
-    let len = vec.len();
-    let (p1, p2): (usize, Option<usize>) =
-        vec.into_iter()
-            .fold((0, Option::<usize>::None), |(p1, p2), (a, b)| {
-                (
-                    p1 + a,
-                    match (p2, b) {
-                        (Some(a), Some(b)) => Some(a + b),
-                        (None, Some(b)) => Some(b),
-                        _ => None,
-                    },
-                )
-            });
-
-    Ok((p1 / len, p2.map(|val| val / len)))
-}
-
-async fn run_days(
-    days: Vec<(PathBuf, u32)>,
-    number_of_runs: usize,
-) -> Result<Vec<(u32, (usize, Option<usize>))>, AocError> {
-    let cargo_folder = cargo_path().await?;
-    let multi = MultiProgress::new();
-
-    // Sort it to get the progress bars in increasing order
-    let mut days = days;
-    days.sort_unstable_by_key(|k| k.1);
-    let days = days
-        .into_iter()
-        .map(|day| {
-            let progress = multi.add(get_progressbar(number_of_runs as u64));
-            progress.set_message(format!("Running day {}", day.1));
-            (day, progress)
-        })
-        .collect::<Vec<_>>();
-
-    Ok(thread_exec(days, |(day, progress)| {
-        let cargo_folder = cargo_folder.clone();
-
-        let res = run_day(cargo_folder, &day, number_of_runs, progress).expect("Running day");
-        (day.1, res)
-    }))
-}
-
-fn print_info(days: Vec<(u32, (usize, Option<usize>))>, not_done: Vec<u32>, number_of_runs: usize) {
+) {
     let unit = get_time_symbol();
-    let red_text = |s: u32| format!("\x1b[0;33;31m{}\x1b[0m", s);
+    let red_text = |s: usize| format!("\x1b[0;33;31m{}\x1b[0m", s);
     let gold_text = |s: &str| format!("\x1b[0;33;10m{}\x1b[0m:", s);
     let silver_text = |s: &str| format!("\x1b[0;34;34m{}\x1b[0m:", s);
 
@@ -222,7 +74,7 @@ fn print_info(days: Vec<(u32, (usize, Option<usize>))>, not_done: Vec<u32>, numb
     println!("STATS:");
     println!("Number of runs: {}:\n", number_of_runs);
 
-    let print_info = |text: String, vec: Vec<(u32, usize)>| {
+    let print_info = |text: String, vec: Vec<(usize, usize)>| {
         println!("{}", text);
 
         let mut data: Vec<_> = vec.iter().map(|(_, time)| *time).collect();
@@ -266,23 +118,375 @@ fn print_info(days: Vec<(u32, (usize, Option<usize>))>, not_done: Vec<u32>, numb
     println!("\nTOTAL TIME: {}{unit}", total);
 }
 
+fn build_day(day: usize, path: PathBuf, progress: &ProgressBar) -> Result<usize, Error> {
+    let bin = format!("day_{:02}", day);
+
+    let mut day_path = path.clone();
+    day_path.push(&path);
+    day_path.push(&bin);
+    day_path.push("main.rs");
+    if !day_path.exists() {
+        return Err(Error {
+            day,
+            r#type: ErrorTypes::NotImplementd,
+        });
+    }
+
+    let res = Command::new("cargo")
+        .args(["build", "--release", "--bin", &bin])
+        .current_dir(path)
+        .output()
+        .ok()
+        .unwrap();
+
+    progress.inc(1);
+    if res.status.success() {
+        Ok(day)
+    } else {
+        let details = extract_comiler_error(String::from_utf8(res.stderr).unwrap());
+        Err(Error {
+            day,
+            r#type: ErrorTypes::CompilerError(details),
+        })
+    }
+}
+
+async fn verify_day(
+    day: usize,
+    path: PathBuf,
+    year: usize,
+    table_display: bool,
+    progress: &ProgressBar,
+) -> Result<BuildRes, Error> {
+    let day_path = day_path(path.clone(), day as u32)
+        .await
+        .unwrap_or_else(|_| panic!("day {day} is build, but could not find the path"));
+
+    let mut input = day_path.clone();
+    input.push("input");
+    if !input.exists() {
+        download_input_file(day as u32, year as i32, &day_path)
+            .await
+            .map_err(|_| Error {
+                day,
+                r#type: ErrorTypes::InputDownloadError,
+            })?;
+    }
+
+    let target = get_target(path, day);
+    let progress = progress.clone();
+
+    let res = Command::new(target)
+        .current_dir(&day_path)
+        .output()
+        .ok()
+        .unwrap();
+
+    if !res.status.success() {
+        let details = extract_runtime_error(res.stderr);
+        if details == "not implemented" {
+            return Err(Error {
+                day,
+                r#type: ErrorTypes::NotImplementd,
+            });
+        }
+
+        return Err(Error {
+            day,
+            r#type: ErrorTypes::RuntimeError(details),
+        });
+    }
+
+    let (_t1, _t2) = parse_get_answers(res);
+    if _t1.is_none() && _t2.is_none() {
+        return Err(Error {
+            day,
+            r#type: ErrorTypes::NotImplementd,
+        });
+    }
+
+    let mut br = BuildRes::new(day, day_path);
+    let res = if table_display {
+        let info = get_day_title_and_answers(day as u32, year as u32)
+            .await
+            .expect("Could not get day title and answer");
+        br.info.title = info.title;
+
+        br.info.correct1 = _t1 == info.part1_answer;
+        br.info.correct2 = _t2 == info.part2_answer;
+
+        br.info.ans1 = info.part1_answer;
+        br.info.ans2 = info.part2_answer;
+
+        Ok(br)
+    } else {
+        Ok(br)
+    };
+    progress.inc(1);
+    res
+}
+
+async fn compile_and_verify_days(
+    days: Vec<usize>,
+    cargo_folder: PathBuf,
+    year: usize,
+    table_display: bool,
+) -> Vec<Result<BuildRes, Error>> {
+    let progress = get_progressbar(days.len() as u64);
+    progress.set_message("compiling");
+
+    let res: Vec<_> = thread_exec(&days, |day| {
+        build_day(*day, cargo_folder.clone(), &progress)
+    });
+
+    progress.reset();
+    progress.set_message("verifying");
+
+    let days: Vec<_> = thread_exec(res, |day| {
+        day.and_then(|day| {
+            let runtime = Runtime::new().unwrap();
+            runtime.block_on(verify_day(
+                day,
+                cargo_folder.clone(),
+                year,
+                table_display,
+                &progress,
+            ))
+        })
+    });
+
+    days
+}
+
+fn run_day(
+    cargo_folder: PathBuf,
+    day_folder: PathBuf,
+    day: usize,
+    number_of_runs: usize,
+    progress: ProgressBar,
+) -> Result<(usize, Option<usize>), AocError> {
+    let target = get_target(cargo_folder, day);
+    let mut vec = Vec::with_capacity(number_of_runs);
+
+    for _ in 0..number_of_runs {
+        let res = Command::new(&target)
+            .current_dir(&day_folder)
+            .envs(std::env::vars())
+            .output()?;
+
+        progress.inc(1);
+        vec.push(parse_get_times(res)?);
+    }
+
+    let len = vec.len();
+    let (p1, p2): (usize, Option<usize>) = vec
+        .into_iter()
+        .fold((0, Option::<usize>::None), |(p1, p2), (a, b)| {
+            (p1 + a, p2.zip(b).map(|(p2, b)| p2 + b).or(b))
+        });
+
+    Ok((p1 / len, p2.map(|val| val / len)))
+}
+
+fn run_days(
+    days: Vec<Result<BuildRes, Error>>,
+    cargo_folder: PathBuf,
+    number_of_runs: usize,
+) -> Result<Vec<Result<BuildRes, Error>>, AocError> {
+    let multi = MultiProgress::new();
+
+    // Sort it to get the progress bars in increasing order
+    let mut days = days;
+    days.sort_unstable_by_key(|k| match k {
+        Ok(k) => k.day,
+        Err(e) => e.day,
+    });
+    let days = days
+        .into_iter()
+        .map(|br| {
+            br.map(|br| {
+                let progress = multi.add(get_progressbar(number_of_runs as u64));
+                progress.set_message(format!("Running day {}", br.day));
+                (br, progress)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(thread_exec(days, |res| {
+        res.map(|(mut br, progress)| {
+            let (p1, p2) = run_day(
+                cargo_folder.clone(),
+                br.path.clone(),
+                br.day,
+                number_of_runs,
+                progress,
+            )
+            .unwrap_or_else(|_| panic!("error running day {}", br.day));
+            br.time = Time(p1, p2);
+            br
+        })
+    }))
+}
+
+fn format_duration(duration: usize) -> String {
+    let unit = get_time_symbol();
+    format!("{}{}", duration, unit)
+}
+
+fn print_table(days: Vec<Result<BuildRes, Error>>, year: usize) {
+    let max_name_len = days
+        .iter()
+        .flatten()
+        .map(|br| br.info.title.len())
+        .max()
+        .unwrap_or(5);
+    let max_part1_len = days
+        .iter()
+        .flatten()
+        .map(|br| br.info.ans1.as_ref().unwrap_or(&"NA".to_string()).len())
+        .max()
+        .unwrap_or(5);
+    let max_part2_len = days
+        .iter()
+        .flatten()
+        .map(|br| br.info.ans2.as_ref().unwrap_or(&"NA".to_string()).len())
+        .max()
+        .unwrap_or(5);
+
+    let max_part1_time_len = days
+        .iter()
+        .flatten()
+        .map(|br| format_duration(br.time.0).len())
+        .max()
+        .unwrap_or(5);
+    let max_part2_time_len = days
+        .iter()
+        .flatten()
+        .map(|br| {
+            br.time
+                .1
+                .map(format_duration)
+                .unwrap_or("NA".to_string())
+                .len()
+        })
+        .max()
+        .unwrap_or(5);
+
+    let part1_header_len = max_part1_len + 8 + max_part1_time_len;
+    let part2_header_len = max_part2_len + 8 + max_part2_time_len;
+
+    let max_total_len = max_name_len + part1_header_len + part2_header_len + 5;
+
+    println!("╔{}╗", "═".repeat(max_total_len + 3));
+    println!(
+        "║ {:^max_total_len$}  ║",
+        format!("🦀 Advent of Code {year} 🦀")
+    );
+    println!(
+        "╠{}╦{}╦{}╣",
+        "═".repeat(max_name_len + 2),
+        "═".repeat(part1_header_len + 2),
+        "═".repeat(part2_header_len + 2),
+    );
+    println!(
+        "║ {:max_name_len$} ║ {:part1_header_len$} ║ {:part2_header_len$} ║",
+        "Day", "Part 1", "Part 2"
+    );
+    println!(
+        "╠{}╬{}╦{}╦{}╬{}╦{}╦{}╣",
+        "═".repeat(max_name_len + 2),
+        "═".repeat(max_part1_len + 2),
+        "═".repeat(max_part1_time_len + 2),
+        "═".repeat(4),
+        "═".repeat(max_part2_len + 2),
+        "═".repeat(max_part2_time_len + 2),
+        "═".repeat(4),
+    );
+
+    for day in days {
+        match day {
+            Ok(day) => {
+                let part1_symbol = if day.info.correct1 { "✅" } else { "❌" };
+                let part2_symbol = if day.info.correct2 { "✅" } else { "❌" };
+
+                println!(
+                    "║ {:max_name_len$} ║ {:max_part1_len$} ║ {:max_part1_time_len$} ║ {} ║ \
+                     {:max_part2_len$} ║ {:max_part2_time_len$} ║ {} ║ ",
+                    day.info.title,
+                    day.info.ans1.unwrap_or("NA".to_string()),
+                    format_duration(day.time.0),
+                    part1_symbol,
+                    day.info.ans2.unwrap_or("NA".to_string()),
+                    day.time.1.map(format_duration).unwrap_or("NA".to_string()),
+                    part2_symbol,
+                );
+            }
+            Err(e) => {
+                let fmt = |txt: &str, s: String| {
+                    let len = txt.len();
+                    let err = s
+                        .chars()
+                        .take(max_total_len - 2 - len)
+                        .collect::<String>()
+                        .trim()
+                        .replace('\n', "")
+                        .to_owned();
+                    format!("{}: {}", txt, err)
+                };
+                let s = match e.r#type {
+                    ErrorTypes::CompilerError(s) => fmt("COMPILER", s),
+                    ErrorTypes::RuntimeError(s) => fmt("RUNTIME", s),
+                    ErrorTypes::NotImplementd => String::from("UNIMPL"),
+                    ErrorTypes::InputDownloadError => String::from("INPUT DOWNLOAD ERROR"),
+                };
+                println!("║ {:^max_total_len$}  ║", s);
+            }
+        }
+    }
+    println!(
+        "╚{}╩{}╩{}╩{}╩{}╩{}╩{}╝",
+        "═".repeat(max_name_len + 2),
+        "═".repeat(max_part1_len + 2),
+        "═".repeat(max_part1_time_len + 2),
+        "═".repeat(4),
+        "═".repeat(max_part2_len + 2),
+        "═".repeat(max_part2_time_len + 2),
+        "═".repeat(4),
+    );
+}
+
 pub async fn tally(matches: &ArgMatches) -> Result<(), AocError> {
-    let number_of_runs: usize = matches
-        .get_one::<String>("runs")
-        .ok_or(AocError::ArgMatches)?
-        .parse()?;
+    let number_of_runs = get_number_of_runs(matches)?;
+    let display_table = matches.get_flag("table");
+
     let cargo_folder = cargo_path().await?;
+    let year = get_year_from_root().await? as usize;
+    let possible_days = get_possible_days(year)?;
+    let days =
+        compile_and_verify_days(possible_days, cargo_folder.clone(), year, display_table).await;
 
-    let (mut have, mut dont) = days().await?;
-    let unimplementeds = build_days(cargo_folder, &have).await?;
+    let mut days = run_days(days, cargo_folder, number_of_runs)?;
+    let mut dont_have = Vec::new();
 
-    have.retain(|elem| !unimplementeds.contains(&elem.1));
-    dont.extend(unimplementeds);
+    days.retain(|elem| {
+        if matches!(elem, Err(e) if e.r#type == ErrorTypes::NotImplementd) {
+            dont_have.push(elem.as_ref().unwrap_err().day);
+            false
+        } else {
+            true
+        }
+    });
 
-    let mut res = run_days(have, number_of_runs).await?;
-    res.sort_unstable_by_key(|v| v.0);
-
-    print_info(res, dont, number_of_runs);
+    if display_table {
+        print_table(days, year);
+    } else {
+        let have = days
+            .into_iter()
+            .flatten()
+            .map(|br| (br.day, (br.time.0, br.time.1)))
+            .collect();
+        print_info(have, dont_have, number_of_runs);
+    }
 
     Ok(())
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -75,15 +75,13 @@ pub fn get_time_symbol() -> String {
 
 #[derive(Debug)]
 pub struct AocInfo {
-    pub day: u32,
-    pub year: u32,
     pub title: String,
     pub part1_answer: Option<String>,
     pub part2_answer: Option<String>,
 }
 
 pub async fn get_day_title_and_answers(day: u32, year: u32) -> Result<AocInfo, AocError> {
-    if let Ok(cache) = read_cache_answers(day, year).await {
+    if let Ok(cache) = read_cache_answers(day).await {
         return Ok(cache);
     }
 
@@ -113,8 +111,6 @@ pub async fn get_day_title_and_answers(day: u32, year: u32) -> Result<AocInfo, A
     let a2 = iter.next();
 
     let info = AocInfo {
-        day,
-        year,
         title: title.to_owned(),
         part1_answer: a1,
         part2_answer: a2,
@@ -154,13 +150,11 @@ pub async fn write_cache_answers(day: u32, info: &AocInfo) -> Result<(), AocErro
     Ok(())
 }
 
-pub async fn read_cache_answers(day: u32, year: u32) -> Result<AocInfo, AocError> {
+pub async fn read_cache_answers(day: u32) -> Result<AocInfo, AocError> {
     let path = get_cache_path(day).await?;
     let res = tokio::fs::read_to_string(path).await?;
     let lines = res.lines().collect::<Vec<_>>();
     Ok(AocInfo {
-        day,
-        year,
         title: lines[0].to_owned(),
         part1_answer: Some(lines[1].to_owned()),
         part2_answer: Some(lines[2].to_owned()),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,6 +15,8 @@ pub mod file;
 pub mod request;
 #[cfg(feature = "submit")]
 pub mod submit;
+#[cfg(feature = "tally")]
+pub mod tally_util;
 
 #[derive(Eq, PartialEq, Clone, Copy)]
 pub enum Task {

--- a/src/util/tally_util.rs
+++ b/src/util/tally_util.rs
@@ -46,10 +46,20 @@ pub enum ErrorTypes {
     InputDownloadError,
     NotImplementd,
 }
-
+impl ToString for ErrorTypes {
+    fn to_string(&self) -> String {
+        match self {
+            ErrorTypes::CompilerError(s) => s.to_owned(),
+            ErrorTypes::RuntimeError(s) => s.to_owned(),
+            ErrorTypes::NotImplementd => String::from("UNIMPL"),
+            ErrorTypes::InputDownloadError => String::from("INPUT DOWNLOAD ERROR"),
+        }
+    }
+}
 #[derive(Debug)]
 pub struct Error {
     pub day: usize,
+    pub title: String,
     pub r#type: ErrorTypes,
 }
 

--- a/src/util/tally_util.rs
+++ b/src/util/tally_util.rs
@@ -1,0 +1,126 @@
+use std::{path::PathBuf, process::Output};
+
+use chrono::Datelike;
+use clap::ArgMatches;
+
+use crate::error::AocError;
+
+use super::get_time_symbol;
+
+#[derive(Debug, Default)]
+pub struct TableInfo {
+    pub title: String,
+    pub ans1: Option<String>,
+    pub ans2: Option<String>,
+
+    pub correct1: bool,
+    pub correct2: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct Time(pub usize, pub Option<usize>);
+
+#[derive(Debug)]
+pub struct BuildRes {
+    pub day: usize,
+    pub path: PathBuf,
+    pub info: TableInfo,
+    pub time: Time,
+}
+
+impl BuildRes {
+    pub fn new(day: usize, path: PathBuf) -> Self {
+        Self {
+            day,
+            path,
+            info: Default::default(),
+            time: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ErrorTypes {
+    CompilerError(String),
+    RuntimeError(String),
+    InputDownloadError,
+    NotImplementd,
+}
+
+#[derive(Debug)]
+pub struct Error {
+    pub day: usize,
+    pub r#type: ErrorTypes,
+}
+
+pub fn extract_comiler_error(stderr: String) -> String {
+    let pos = stderr.find(": ").unwrap();
+    let mut split = stderr[pos + 2..].split('\n');
+    split.next().unwrap().to_owned()
+}
+
+pub fn extract_runtime_error(stderr: Vec<u8>) -> String {
+    let s = String::from_utf8(stderr).unwrap();
+    let mut split = s.split('\n');
+    split.nth(1).unwrap().to_string()
+}
+
+pub fn get_number_of_runs(matches: &ArgMatches) -> Result<usize, AocError> {
+    Ok(matches
+        .get_one::<String>("runs")
+        .ok_or(AocError::ArgMatches)?
+        .parse()?)
+}
+
+pub fn get_possible_days(year: usize) -> Result<Vec<usize>, AocError> {
+    let now = chrono::Utc::now();
+
+    if year as i32 == now.year() {
+        if now.month() < 12 {
+            Err(AocError::InvalidMonth)
+        } else {
+            Ok((1..=now.day() as usize).collect())
+        }
+    } else {
+        Ok((1..=25).collect())
+    }
+}
+
+pub fn parse_get_times(output: Output) -> Result<(usize, Option<usize>), AocError> {
+    let unit = get_time_symbol();
+    let parse = |line: &str| -> Result<usize, AocError> {
+        let start = line.find('(').ok_or(AocError::ParseStdout)?;
+        let stop = line
+            .find(&format!("{unit})"))
+            .ok_or(AocError::ParseStdout)?;
+        Ok(line[start + 1..stop].parse().unwrap())
+    };
+    let text = std::str::from_utf8(&output.stdout).unwrap();
+    let mut iter = text.split('\n');
+    let p1 = parse(iter.next().unwrap())?;
+    let p2 = iter.next().and_then(|n| parse(n).ok());
+
+    Ok((p1, p2))
+}
+
+pub fn parse_get_answers(output: Output) -> (Option<String>, Option<String>) {
+    let text = std::str::from_utf8(&output.stdout).unwrap();
+    let strip = strip_ansi_escapes::strip(text);
+    let text = std::str::from_utf8(&strip).unwrap();
+
+    let parse = |line: &str| {
+        line.split_ascii_whitespace()
+            .next_back()
+            .map(|s| s.to_string())
+    };
+    let mut iter = text.split('\n');
+    (iter.next().and_then(parse), iter.next().and_then(parse))
+}
+
+pub fn get_target(path_buf: PathBuf, day: usize) -> PathBuf {
+    let bin = format!("day_{:02}", day);
+    let mut path_buf = path_buf;
+    path_buf.push("target/release");
+    path_buf.push(&bin);
+    path_buf
+}


### PR DESCRIPTION
# Changes: 
* adds the `--table` subcommand from some sweets graphics

Compiler and runtime errors for a day is included in the row. Unimplemented days (programs that panics with the message 'unimplemented') are removed from the list. See Image#2.  

## Tests
Look fine on ubuntu and windows. Idk about Mac, but I expect it to work 🤷 

## images:
![image](https://github.com/user-attachments/assets/697ecee0-f98a-433a-9762-b804ce9d6919)
![image](https://github.com/user-attachments/assets/ccd9febb-6938-4ca3-9de4-5eb5d3d5137c)


