### PR TITLE
add: prefer folder day over actual day or flag

### DIFF
--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -9,6 +9,42 @@ use reqwest::StatusCode;
 use super::request::AocRequest;
 use crate::error::AocError;
 
+pub fn get_day_from_path() -> Result<Option<u32>, AocError> {
+    let get_day = |s: &str| -> Option<u32> {
+        let mut num = 0;
+        let mut i = 1;
+
+        for ch in s.chars() {
+            if let Some(d) = ch.to_digit(10) {
+                if num == 0 && d == 0 {
+                    continue;
+                }
+                num += d * i;
+                i *= 10;
+            }
+        }
+
+        (1..=25).contains(&num).then_some(num)
+    };
+
+    let mut cwd = std::env::current_dir()?;
+
+    loop {
+        let name = cwd.file_name();
+        let name = name
+            .ok_or(AocError::InvalidRunDay)?
+            .to_str()
+            .ok_or(AocError::InvalidRunDay)?;
+
+        if let Some(day) = get_day(&name) {
+            return Ok(Some(day));
+        }
+        if !cwd.pop() {
+            return Ok(None);
+        }
+    }
+}
+
 pub fn get_root_path() -> Result<std::path::PathBuf, AocError> {
     let mut cwd = std::env::current_dir()?;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use clap::ArgMatches;
 use file::get_root_path;
 
-use self::{file::day_path, request::AocRequest};
+use self::{
+    file::{day_path, get_day_from_path},
+    request::AocRequest,
+};
 use crate::error::AocError;
 
 pub mod file;
@@ -36,6 +39,13 @@ pub fn get_day(matches: &ArgMatches) -> Result<u32, AocError> {
     if !(1..=25).contains(&day) {
         Err(AocError::InvalidRunDay)
     } else {
+        let source = matches.value_source("day").unwrap();
+        if source == clap::parser::ValueSource::DefaultValue {
+            if let Ok(Some(day)) = get_day_from_path() {
+                return Ok(day);
+            }
+        }
+
         Ok(day)
     }
 }


### PR DESCRIPTION
With this, if you're in a folder, say day_02, then `cargo aoc r` would prioritize the  folder day rather than the current day. The priority ordering is:
1. day flag `-d` if supplied
2. folder day
3. current day

fix #60 