### PR TITLE
update: how we pass arguments to the compiler

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,10 +72,11 @@ async fn main() -> Result<(), AocError> {
                         .required(false)
                         .help("Submit answer")
                         .conflicts_with("test"),
-                    Arg::new("Args")
-                        .trailing_var_arg(true)
+                    Arg::new("args")
                         .num_args(1..)
-                        .help("Arguments to send to compiler"),
+                        .trailing_var_arg(true)
+                        .allow_hyphen_values(true)
+                        .help("Arguments after -- will passed to cargo"),
                 ])
                 .about("Runs the given day"),
         )

--- a/src/run.rs
+++ b/src/run.rs
@@ -53,14 +53,17 @@ pub async fn run(matches: &ArgMatches) -> Result<(), AocError> {
     let input = get_input_file(matches);
 
     let trailing_args = matches
-        .get_one::<String>("Args")
-        .cloned()
-        .unwrap_or_default();
-    let cmd = if !trailing_args.is_empty() {
-        cmd!("cargo", "run", trailing_args, "--color", "always", input)
-    } else {
-        cmd!("cargo", "run", "--color", "always", input)
-    };
+        .get_many::<&str>("args")
+        .unwrap_or_default()
+        .copied()
+        .collect::<Vec<_>>();
+
+    let args = std::iter::once("run")
+        .chain(trailing_args)
+        .chain(["--color", "always"])
+        .chain(std::iter::once(input));
+
+    let cmd = cmd("cargo", args);
     let reader = cmd.dir(dir).stderr_to_stdout().reader()?;
 
     let reader = BufReader::new(reader);


### PR DESCRIPTION
# Changes:
Pass argument to the compiler with `--`.
This then removes the need for the `--release` flag for run, since it can be done with `cargo aoc r -- --release`, as well as the `--compiler-flags` option, but maybe we should add an `env` flag instead for this

Fix #77 