### PR TITLE
fix tally: again

### DIFF
--- a/src/tally/util.rs
+++ b/src/tally/util.rs
@@ -39,10 +39,11 @@ pub fn get_possible_days(year: usize) -> Result<Vec<usize>, AocError> {
     }
 
     if year as i32 == now.year() {
-        if now.month() < 12 {
-            Err(AocError::InvalidMonth)
+        if now.month() == 12 {
+            let day = now.day() as usize;
+            Ok((1..=day.min(LAST_DAY_2025)).collect())
         } else {
-            Ok((1..=now.day() as usize).collect())
+            Err(AocError::InvalidMonth)
         }
     } else {
         Ok((1..=LAST_DAY_2025).collect())


### PR DESCRIPTION
This is the function for fetching the possible number of days. If we're in december, then the possible days is the 1st up to the current day,  i.e. on december 7th, we get 1..=7, but only up to day 12, as specified by the `min`