### PR TITLE
Fix/year+day

### DIFF
--- a/src/language/config.rs
+++ b/src/language/config.rs
@@ -107,6 +107,10 @@ impl Runner for Toolchain<RunState> {
     }
 }
 
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s)
+}
+
 fn transform_command(
     command: &str,
     running_args: &RunningArgs,
@@ -118,7 +122,7 @@ fn transform_command(
         let input = running_args.common.input_file.display().to_string();
         let rest = running_args.arguments.join(" ");
 
-        command.push_str(&format!(" {} {}", input, rest));
+        command.push_str(&format!(" {} {}", shell_quote(&input), rest));
     }
     if cfg!(windows) {
         ("cmd".to_owned(), vec!["/c".to_string(), command])

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,7 +10,10 @@ use crate::{
     error::AocError,
     language::REGISTER,
     util::{
-        file::{day_path, download_input_file, get_parse_config, get_root_path, get_running_args},
+        file::{
+            day_path, download_input_file, get_parse_config, get_root_path, get_running_args,
+            get_year_from_path,
+        },
         get_day,
     },
 };
@@ -18,13 +21,7 @@ use crate::{
 pub async fn run(matches: &ArgMatches) -> Result<(), AocError> {
     let day = get_day(matches)?;
     let path = get_root_path()?;
-    let year = path
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .parse::<i32>()
-        .unwrap();
+    let year = get_year_from_path(&path)?;
 
     let dir = day_path(&path, day).await?;
 

--- a/src/tally/mod.rs
+++ b/src/tally/mod.rs
@@ -9,9 +9,12 @@ use crate::{
             get_verified_days,
         },
         print_fns::print_table,
-        util::{get_number_of_runs, get_possible_days, get_year_from_path},
+        util::{get_number_of_runs, get_possible_days},
     },
-    util::{file::get_root_path, verify_token},
+    util::{
+        file::{get_root_path, get_year_from_path},
+        verify_token,
+    },
 };
 
 mod ctx;
@@ -26,7 +29,7 @@ pub async fn tally(matches: &ArgMatches) -> Result<(), AocError> {
     let number_of_runs = get_number_of_runs(matches)?;
 
     let root = get_root_path()?;
-    let year = get_year_from_path(&root)?;
+    let year = get_year_from_path(&root)? as usize;
     let days = get_possible_days(year)?;
 
     let mut ctx = PipelineCtx::new(year, root.clone(), &days).await?;

--- a/src/tally/util.rs
+++ b/src/tally/util.rs
@@ -93,15 +93,6 @@ pub fn get_number_of_runs(matches: &ArgMatches) -> Result<usize, AocError> {
         .parse()?)
 }
 
-pub fn get_year_from_path(path: &Path) -> Result<usize, AocError> {
-    Ok(path
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .parse::<usize>()?)
-}
-
 pub async fn prepare_args(ctx: &PipelineCtx, day_path: &Path, day: usize) -> Option<RunningArgs> {
     let main = find_file(day_path, "main", Some(&REGISTER.compiler_exts()))?;
     let input_path = day_path.join("input");

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -52,19 +52,35 @@ pub fn get_day_from_path() -> Result<Option<u32>, AocError> {
     }
 }
 
+pub fn get_year_from_path(year: &Path) -> Result<i32, AocError> {
+    let regex = Regex::new("(\\d{4})").unwrap();
+    let name = year.file_name().ok_or_else(std::io::Error::last_os_error)?;
+    let s = name.to_str().unwrap();
+    let Some(captures) = regex.captures(s) else {
+        return Err(AocError::InvalidYear);
+    };
+
+    let year = captures[1].parse().unwrap();
+    Ok(year)
+}
+
 pub fn get_root_path() -> Result<std::path::PathBuf, AocError> {
     let mut cwd = std::env::current_dir()?;
 
+    let regex = Regex::new("(\\d{4})").unwrap();
     loop {
         let name = cwd.file_name().ok_or_else(std::io::Error::last_os_error)?;
+        let s = name.to_str().unwrap();
 
-        let Ok(year): Result<i32, _> = name.to_str().unwrap().parse() else {
+        let Some(captures) = regex.captures(s) else {
             if !cwd.pop() {
                 return Err(AocError::InvalidYear);
             }
             continue;
         };
 
+        // Beucase of the regex, this has to be a number
+        let year = captures[1].parse::<i32>().unwrap();
         let current_year = chrono::Utc::now().year();
 
         if (2015..=current_year).contains(&year) {


### PR DESCRIPTION
The commits in this PR adds support for spaces and other formats. Now, you root folder can be anything, as long as it contains the year
2025 ✅ 
Year-2025 ✅ 
"Year 2025" ✅ 

Your day path can be anything, as long as it contains the number:
day_01 ✅ 
day-1 ✅ 
"day - 01" ✅ 

And I had to escape the input file's path as well