### PR TITLE
Feat/toml1.1

### DIFF
--- a/.languages.toml
+++ b/.languages.toml
@@ -1,7 +1,6 @@
 [toolchain.rust]
 ext = "rs"
 run = "cargo run --color always {args}"
-dir = "{day}"
 compile = {
     build = "cargo build --release",
     execute = "{day}/target/release/{name:day}"

--- a/.languages.toml
+++ b/.languages.toml
@@ -2,7 +2,8 @@
 ext = "rs"
 run = "cargo run --color always {args}"
 dir = "{day}"
-[toolchain.rust.compile]
-build = "cargo build --release"
-execute = "{day}/target/release/{name:day}"
+compile = {
+    build = "cargo build --release",
+    execute = "{day}/target/release/{name:day}"
+}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ duct = "1.1.0"
 thiserror = "2.0.17"
 regex = "1.12.2"
 serde_regex = "1.1.0"
-toml = "0.9.8"
+toml = "0.9.10"
 futures = "0.3.31"
 
 

--- a/src/language/config.rs
+++ b/src/language/config.rs
@@ -141,6 +141,8 @@ fn run_command<T>(
     if let Some(dir) = &t.dir {
         let dir = expand_templates(dir, args)?;
         cmd = cmd.dir(dir);
+    } else {
+        cmd = cmd.dir(&args.common.day_folder);
     }
 
     Ok(cmd)


### PR DESCRIPTION
# Changes:
* Support toml 1.1 syntax
* Set default Command::dir to `day_folder` if none is supplied. Less clutter in the lang file